### PR TITLE
meta-qcom-distro: select package_ipk

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -24,6 +24,9 @@ PACKAGECONFIG:append:pn-systemd = " resolved networkd"
 IMAGE_CLASSES += "image_types_qcom"
 IMAGE_FSTYPES += "qcomflash"
 
+# Set a default package class to avoid surprises
+PACKAGE_CLASSES = "package_ipk"
+
 # Avoid to duplicate the rootfs tarball by generating both tar.gz/tar.xz
 IMAGE_FSTYPES:remove = "tar.gz"
 


### PR DESCRIPTION
This is heavily based on the KAS config from meta-qcom-hwe.git

The meta-qcom layer is locked to a commit that still has initramfs-qcom-image, the build won't start otherwise. This also includes inherits that should *not* be in the CI config, but in the DISTRO.conf.