### PR TITLE
Update layer.conf 

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_qcom-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-distro = "10"
 
 LAYERDEPENDS_qcom-distro = "core qcom"
-LAYERSERIES_COMPAT_qcom-distro = "styhead"
+LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS        += "qcom-distro"
 BBFILE_PATTERN_qcom-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-distro = "10"
 
-LAYERDEPENDS_qcom-distro = "core qcom qcom-hwe"
+LAYERDEPENDS_qcom-distro = "core qcom"
 LAYERSERIES_COMPAT_qcom-distro = "styhead"


### PR DESCRIPTION
Update layer.conf to reflect compatibility with walnascar release and drop deprecated qcom-hwe dependencies.