### PR TITLE
Update INITRAMFS_IMAGE to 'initramfs-rootfs-image'

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -29,7 +29,7 @@ IMAGE_ROOTFS_ALIGNMENT = "4096"
 
 # Pull in the initrd image by default
 INITRAMFS_IMAGE_BUNDLE ?= "1"
-INITRAMFS_IMAGE = "initramfs-qcom-image"
+INITRAMFS_IMAGE = "initramfs-rootfs-image"
 
 INHERIT += "buildhistory"
 INHERIT += "image-buildinfo"


### PR DESCRIPTION
'initramfs-qcom-image' is no longer available in meta-qcom layer. Use 'initramfs-rootfs-image' as INITRAMFS_IMAGE in its place. 