### PR TITLE
Remove linux-yocto 6.6 bbappend

### DIFF
--- a/recipes-kernel/linux/linux-yocto/kernel_cmdline_extra.cfg
+++ b/recipes-kernel/linux/linux-yocto/kernel_cmdline_extra.cfg
@@ -1,2 +1,0 @@
-#KERNEL_CMDLINE_EXTRA not honored so hard code it for now
-CONFIG_CMDLINE="root=/dev/disk/by-partlabel/system rw rootwait console=ttyMSM0,115200n8 pcie_pme=nomsi earlycon"

--- a/recipes-kernel/linux/linux-yocto_6.6.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.6.bbappend
@@ -1,7 +1,0 @@
-#This is a temp fix to add kernel_cmdline.
-
-FILESEXTRAPATHS:prepend := "${THISDIR}/linux-yocto:"
-
-SRC_URI:append:qcom = " \
-	file://kernel_cmdline_extra.cfg \
-"


### PR DESCRIPTION
Remove linux-yocto_6.6 append and related cfgs, as it was removed from OE-Core