### PR TITLE
 Update usb-debugging-enabled flag path in image-adbd.bbclass

### DIFF
--- a/classes/image-adbd.bbclass
+++ b/classes/image-adbd.bbclass
@@ -1,13 +1,13 @@
 # This class installs adbd into the target image.
 # The adbd daemon is disabled unless IMAGE_FEATURES contains the 'enable-adbd'
-# Also one can disable adbd by removing /var/usb-debugging-enabled from rootfs manually.
+# Also one can disable adbd by removing /etc/usb-debugging-enabled from rootfs manually.
 
 IMAGE_FEATURES[validitems] += "enable-adbd"
 
 PACKAGE_INSTALL:append = " ${@bb.utils.contains('IMAGE_FEATURES', [ 'enable-adbd' ], 'android-tools-adbd', '',d)} "
 
 enable_adbd_at_boot () {
-	touch ${IMAGE_ROOTFS}/var/usb-debugging-enabled
+	touch ${IMAGE_ROOTFS}/etc/usb-debugging-enabled
 }
 
 ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('IMAGE_FEATURES', [ 'enable-adbd' ], 'enable_adbd_at_boot; ', '',d)}"


### PR DESCRIPTION
android-tools recipe in master branch of meta-oe is now expecting usb debugging flag under /etc. Update image-adbd.bbclass to reflect the same for adb to work.

(Ref: https://git.openembedded.org/meta-openembedded/commit/meta-oe/recipes-devtools/android-tools?id=8106cfe769aa3f0ebdff7a1caed018f9ab49a090)