### PR TITLE
qcom-wayland: add 'opengl' to DISTRO_FEATURES

### DIFF
--- a/conf/distro/qcom-wayland.conf
+++ b/conf/distro/qcom-wayland.conf
@@ -2,7 +2,7 @@ require conf/distro/include/qcom-base.inc
 
 DISTRO_NAME = "QCOM Reference Distro with Wayland"
 
-DISTRO_FEATURES:append = " wayland"
+DISTRO_FEATURES:append = " wayland opengl"
 
 DISTROOVERRIDES = "qcom-wayland"
 


### PR DESCRIPTION
To get the GPU completely working, 'opengl' needs to be enabled. The immediate effect of this is that the firmware packagegroup helpers in meta-qcom start including GPU firmware.