### PR TITLE
qcom-console-image: drop libgomp-dev and libgomp-staticdev

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -12,8 +12,6 @@ CORE_IMAGE_BASE_INSTALL += " \
 
 CORE_IMAGE_EXTRA_INSTALL += " \
     libgomp \
-    libgomp-dev \
-    libgomp-staticdev \
 "
 
 # docker pulls runc/containerd, which in turn recommend lxc unecessarily


### PR DESCRIPTION
qcom-console-image doesn't provide development environment. As such, there is no point in installing libgomp-dev and especially libgomp-staticdev into the image. Drop those packages from CORE_IMAGE_EXTRA_INSTALL.