### PR TITLE
qcom-base.inc: add `wifi` to `DISTRO_FEATURES`

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -11,7 +11,7 @@ TARGET_VENDOR = "-qcom"
 # to make the python below work. Local, site and auto.conf will override it.
 TCMODE ?= "default"
 
-DISTRO_FEATURES:append = " pam overlayfs ptest efi"
+DISTRO_FEATURES:append = " pam overlayfs ptest efi wifi"
 
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"


### PR DESCRIPTION
Among other things, the packagegroups in meta-qcom.git will only include wifi firmware if DISTRO_FEATURES contains 'wifi'.