### PR TITLE
Drop read-only-rootfs from IMAGE_FEATURES

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -2,7 +2,7 @@ SUMMARY = "Minimal image"
 
 LICENSE = "BSD-3-Clause-Clear"
 
-IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging enable-adbd read-only-rootfs"
+IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging enable-adbd"
 
 inherit core-image features_check extrausers image-adbd
 


### PR DESCRIPTION
Making entire rootfs as read-only breaks Ostree usage. It requires the OS read-only content is limited only to /usr. Dropping read-only-rootfs from IMAGE_FEATURES for now validate OStree.