### PR TITLE
qcom-base.inc: explicitly set DISTRO_VERSION

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -1,4 +1,4 @@
-DISTRO_VERSION ??= "0.0"
+DISTRO_VERSION = "2.0"
 
 # SDK variables.
 SDK_VERSION = "${DISTRO_VERSION}"


### PR DESCRIPTION
Using ??= will use the `DISTRO_VERSION ?= "nodistro.0"` from `default-distrovars.inc`, which is not what we want. Explicitly set it to `2.0` to mark it as the preparation for QLI2.x that it is.