### PR TITLE
Add bluetooth, wifi to DISTRO_FEATURES

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -11,7 +11,7 @@ TARGET_VENDOR = "-qcom"
 # to make the python below work. Local, site and auto.conf will override it.
 TCMODE ?= "default"
 
-DISTRO_FEATURES:append = " pam overlayfs ptest efi"
+DISTRO_FEATURES:append = " pam overlayfs ptest efi wifi bluetooth"
 
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"


### PR DESCRIPTION
To get connectivity working, firmware package groups in meta-qcom should include Bluetooth and Wi-Fi firmware, which are controlled by the bluetooth and wifi DISTRO_FEATURES