### PR TITLE
qcom-base: add pni-names to DISTRO_FEATURES

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -11,7 +11,7 @@ TARGET_VENDOR = "-qcom"
 # to make the python below work. Local, site and auto.conf will override it.
 TCMODE ?= "default"
 
-DISTRO_FEATURES:append = " pam overlayfs ptest efi wifi bluetooth"
+DISTRO_FEATURES:append = " pam overlayfs ptest efi wifi bluetooth pni-names"
 
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"


### PR DESCRIPTION
Enable predictable network interface names by default in order to allow a stable interface naming during boot.

Without pni-names the interfaces assigned are done at random order, which is an issue on devices with multiple network interfaces such as qcs9100-ride-sx.