### PR TITLE
qcom-x11: add X11 based distro config

### DIFF
--- a/conf/distro/qcom.conf
+++ b/conf/distro/qcom.conf
@@ -2,8 +2,7 @@ require conf/distro/include/qcom-base.inc
 
 DISTRO_NAME = "QCOM Reference Distro with Wayland"
 
-DISTRO_FEATURES:append = " wayland opengl"
+DISTRO_FEATURES:append = " wayland x11 opengl vulkan"
 
 DISTROOVERRIDES = "qcom-wayland"
 
-DISTRO_FEATURES:remove = "x11"


### PR DESCRIPTION
This uses the same base as the qcom-wayland distro, but enables X11 instead. This is needed for showing things like XFCE that don't have a native wayland port yet.