### PR TITLE
RFC: Add meta-xfce as a dynamic layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,8 +12,10 @@ BBFILE_PRIORITY_qcom-distro = "10"
 LAYERDEPENDS_qcom-distro = " \
     core \
     meta-python \
+    multimedia-layer \
     networking-layer \
     openembedded-layer \
     qcom \
+    xfce-layer \
 "
 LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar"

--- a/recipes-multimedia/libcamera/libcamera_%.bbappend
+++ b/recipes-multimedia/libcamera/libcamera_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom = " gst"

--- a/recipes-products/images/qcom-xfce-demo-image.bb
+++ b/recipes-products/images/qcom-xfce-demo-image.bb
@@ -1,0 +1,30 @@
+require qcom-minimal-image.bb
+
+LICENSE = "MIT"
+
+DESCRIPTION = "An XFCE demo image for Qualcomm machines"
+SUMMARY = "An XFCE demo image."
+
+export IMAGE_BASENAME = "Qualcomm-XFCE-demo-image"
+
+IMAGE_FEATURES += "x11"
+REQUIRED_DISTRO_FEATURES += "x11 opengl"
+
+CORE_IMAGE_EXTRA_INSTALL += " \
+    packagegroup-qcom-distro-xfce \
+    \
+    packagegroup-qcom-utilities \
+    \
+    alsa-utils \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
+    ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-plugins-bad", "", d)} \
+    ${@bb.utils.contains("LICENSE_FLAGS_ACCEPTED", "commercial", "gstreamer1.0-libav", "", d)} \
+    libcamera \
+    libcamera-gst \
+    pipewire \
+    v4l-utils \
+    yavta \
+"
+
+SYSTEMD_DEFAULT_TARGET = "graphical.target"

--- a/recipes-products/packagegroups/packagegroup-qcom-distro-xfce.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-distro-xfce.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Packagegroups for XFCE related tasks"
+DESCRIPTION = "Package group bringing XFCE to your device"
+
+inherit packagegroup
+
+PACKAGES = "${PN}"
+
+# Epiphany dlopen()s libgles3, drag in mesa-demos both as a workaround as well
+# as having the demos available
+RDEPENDS:${PN} = " \
+    cheese \
+    eog \
+    epiphany \
+    evince \
+    gedit \
+    mesa-demos \
+    packagegroup-xfce-base \
+"

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -2,7 +2,15 @@ SUMMARY = "Userspace utilities for QCOM platforms"
 
 inherit packagegroup
 
-PACKAGES = " \
+PACKAGES += " \
+    ${PN}-filesystem-utils \
+    ${PN}-gpu-utils \
+    ${PN}-network-utils \
+    ${PN}-support-utils \
+    "
+
+# Have ${PN} drag in all of the subpackages
+RDEPENDS:${PN} = " \
     ${PN}-filesystem-utils \
     ${PN}-gpu-utils \
     ${PN}-network-utils \

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -20,9 +20,11 @@ RDEPENDS:${PN}-filesystem-utils = " \
 RDEPENDS:${PN}-gpu-utils = " \
     clinfo \
     kmscube \
-    libopencl-mesa \
     mesa-demos \
     vulkan-tools \
+"
+RRECOMMENDS:${PN}-gpu-utils = " \
+    libopencl-mesa \
 "
 
 RDEPENDS:${PN}-network-utils = " \


### PR DESCRIPTION
This adds the recipe used for the EW25 demo, as part of a dynamic layer setup. This should hide the recipe until the user has included meta-xfce and all its dependencies.