### PR TITLE
packagegroup-qcom: drop library packages

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom.bbappend
+++ b/recipes-products/packagegroups/packagegroup-qcom.bbappend
@@ -4,11 +4,10 @@ PACKAGES += " \
     ${PN}-support-utils \
     "
 
+# libinput is not just a library, it also contains udev rules
 RDEPENDS:${PN}-support-utils = " \
     libinput \
     libinput-bin \
-    libnl \
-    libxml2 \
     procps \
     "
 


### PR DESCRIPTION
Drop libxml2 and libnl from packagegroup-qcom-support-utils. If they are required for a paritcular package, that package should properly declare a dependency on them. I've kept libinput for now, as it contains udev rules in addition to the library.