### PR TITLE
image-adbd.bbclass: add missing copyright and license declaration

### DIFF
--- a/classes/image-adbd.bbclass
+++ b/classes/image-adbd.bbclass
@@ -1,3 +1,9 @@
+#
+# Copyright (c) 2024 Linaro
+# Copyright (c) 2024-2025 Qualcomm Innovation Center, Inc.
+#
+# SPDX-License-Identifier: MIT
+
 # This class installs adbd into the target image.
 # The adbd daemon is disabled unless IMAGE_FEATURES contains the 'enable-adbd'
 # Also one can disable adbd by removing /etc/usb-debugging-enabled from rootfs manually.


### PR DESCRIPTION
We enforce copyright and license declaration for bbclass files as part of our repolinter logic.