### PR TITLE
Define packagegroup-qcom-utilities

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause-Clear"
 IMAGE_FEATURES += "package-management ssh-server-openssh"
 
 CORE_IMAGE_BASE_INSTALL += " \
-    packagegroup-qcom-support-utils \
+    packagegroup-qcom-utilities-support-utils \
 "
 
 CORE_IMAGE_EXTRA_INSTALL += " \

--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -11,7 +11,7 @@ REQUIRED_DISTRO_FEATURES = "pam systemd"
 
 CORE_IMAGE_BASE_INSTALL += " \
     kernel-modules \
-    packagegroup-qcom-filesystem-utils \
+    packagegroup-qcom-utilities-filesystem-utils \
 "
 
 EXTRA_USERS_PARAMS = "\

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -1,13 +1,13 @@
+SUMMARY = "Userspace utilities for QCOM platforms"
 
-PACKAGES += " \
+inherit packagegroup
+
+PACKAGES = " \
     ${PN}-filesystem-utils \
     ${PN}-support-utils \
     "
 
-# libinput is not just a library, it also contains udev rules
 RDEPENDS:${PN}-support-utils = " \
-    libinput \
-    libinput-bin \
     procps \
     "
 


### PR DESCRIPTION
Define a package group with common utilities required for QCOM images. 

Previously, these utilities were added to packagegroup-qcom via a bbappend. However, some of the utilities, like libinput, force the PACKAGE_ARCH to be updated, which can cause confusion for users.

Dropping the append and adding these utilities in a new packagegroup would be a much cleaner implementation.