### PR TITLE
systemd bbappend: disable 'mac' policy for pni-names

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,9 @@
+# This disables the 'mac' policy for pni-names
+# We do not want MAC address based naming, for example the wifi on RB1
+# gets a new MAC address every boot *and* doesn't support any of the
+# naming features. This leads to a new, unpredictable interface name on
+# every boot
+
+do_install:append:qcom() {
+	sed -i -e 's: mac::g' ${D}${nonarch_libdir}/systemd/network/99-default.link
+} 


### PR DESCRIPTION
We do not want MAC address based naming, for example the wifi on RB1 gets a new MAC address every boot *and* doesn't support any of the naming features. This leads to a new, unpredictable interface name on every boot.

Having 'wlan0' and 'eth0' for such interfaces is better than 'wn<random mac>', but we do want supported interfaces (e.g. PCIe and USB attached ones) to get renamed, so disabling pni-names completely is unwanted.