### PR TITLE
qcom distro: GCC 14.x was removed from OE-core, remove version lock

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -44,5 +44,3 @@ require conf/distro/include/yocto-uninative.inc
 
 INHERIT += "uninative"
 
-# GCC Version
-GCCVERSION = "14.2%"


### PR DESCRIPTION
Locking GCC to an unavailable errors does nothing but generate warnings:

  WARNING: versions of gcc-runtime available: 15.1.0
  WARNING: preferred version 14.2% of gcc not available (for item cpp)
  WARNING: versions of gcc available: 15.1.0

Drop the version lock completely for the master branch.