### PR TITLE
Bump GCCVERSION to 15.1%

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -45,4 +45,4 @@ require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
 
 # GCC Version
-GCCVERSION = "14.2%"
+GCCVERSION = "15.1%"


### PR DESCRIPTION
The OE-Core master branch has been updated to use the GCC 15. Update the GCCVERSION in the distro configuration to reflect this.