### PR TITLE
Minor image cleanups

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -2,8 +2,6 @@ require qcom-minimal-image.bb
 
 SUMMARY = "Basic console image"
 
-LICENSE = "BSD-3-Clause-Clear"
-
 IMAGE_FEATURES += "package-management ssh-server-openssh"
 
 CORE_IMAGE_BASE_INSTALL += " \

--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -13,7 +13,3 @@ CORE_IMAGE_BASE_INSTALL += " \
 CORE_IMAGE_EXTRA_INSTALL += " \
     libgomp \
 "
-
-# docker pulls runc/containerd, which in turn recommend lxc unecessarily
-
-BAD_RECOMMENDATIONS:append = " lxc"

--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -2,7 +2,5 @@ require qcom-console-image.bb
 
 SUMMARY = "Basic Wayland image with Weston"
 
-LICENSE = "BSD-3-Clause-Clear"
-
 # let's make sure we have a good image.
 REQUIRED_DISTRO_FEATURES += "wayland"


### PR DESCRIPTION
* Removing bad recommendation for lxc (not required and not used)
* Remove LICENSE duplication between image recipes