### PR TITLE
layer: add dependency on openembedded-layer

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,5 @@ BBFILE_COLLECTIONS        += "qcom-distro"
 BBFILE_PATTERN_qcom-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-distro = "10"
 
-LAYERDEPENDS_qcom-distro = "core qcom"
+LAYERDEPENDS_qcom-distro = "core openembedded-layer qcom"
 LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar"


### PR DESCRIPTION
Add explicit layer dependency on openembedded-layer to satisfy dependency required for adb support.

While we could change the image_adbd class to only depend on android-tools-adbd when openembedded-layer is available, it is better to assume it will always be for better user experience.

Since we also expect to extend our distro images to also include additional recipes from the same layer, better to just have it as an explicit dependency.