### PR TITLE
Extend images to include network utilities

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -9,5 +9,11 @@ BBFILE_COLLECTIONS        += "qcom-distro"
 BBFILE_PATTERN_qcom-distro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom-distro = "10"
 
-LAYERDEPENDS_qcom-distro = "core openembedded-layer qcom"
+LAYERDEPENDS_qcom-distro = " \
+    core \
+    meta-python \
+    networking-layer \
+    openembedded-layer \
+    qcom \
+"
 LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar"

--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -5,6 +5,7 @@ SUMMARY = "Basic console image"
 IMAGE_FEATURES += "package-management ssh-server-openssh"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    packagegroup-qcom-utilities-network-utils \
     packagegroup-qcom-utilities-support-utils \
 "
 

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -4,6 +4,7 @@ inherit packagegroup
 
 PACKAGES = " \
     ${PN}-filesystem-utils \
+    ${PN}-network-utils \
     ${PN}-support-utils \
     "
 
@@ -13,6 +14,18 @@ RDEPENDS:${PN}-filesystem-utils = " \
     e2fsprogs-mke2fs \
     e2fsprogs-resize2fs \
     e2fsprogs-tune2fs \
+    "
+
+RDEPENDS:${PN}-network-utils = " \
+    ethtool \
+    iproute2 \
+    iw \
+    networkmanager \
+    openssh-scp \
+    openssh-ssh \
+    rsync \
+    smbclient \
+    tcpdump \
     "
 
 RDEPENDS:${PN}-support-utils = " \

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -7,14 +7,14 @@ PACKAGES = " \
     ${PN}-support-utils \
     "
 
-RDEPENDS:${PN}-support-utils = " \
-    procps \
-    "
-
 RDEPENDS:${PN}-filesystem-utils = " \
     e2fsprogs \
     e2fsprogs-e2fsck \
     e2fsprogs-mke2fs \
     e2fsprogs-resize2fs \
     e2fsprogs-tune2fs \
+    "
+
+RDEPENDS:${PN}-support-utils = " \
+    procps \
     "


### PR DESCRIPTION
- Add packagegroup-qcom-utilities-network-utils covering additional network related tooling and utilities
- Add meta-networking and meta-python (dependency of meta-networking) as meta-qcom-distro layer dependency
