### PR TITLE
Remove system user and add password for root

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -2,7 +2,7 @@ SUMMARY = "Minimal image"
 
 LICENSE = "BSD-3-Clause-Clear"
 
-IMAGE_FEATURES += "splash tools-debug allow-empty-password empty-root-password allow-root-login post-install-logging enable-adbd"
+IMAGE_FEATURES += "splash tools-debug allow-root-login post-install-logging enable-adbd"
 
 inherit core-image features_check extrausers image-adbd
 
@@ -13,6 +13,9 @@ CORE_IMAGE_BASE_INSTALL += " \
     kernel-modules \
     packagegroup-qcom-utilities-filesystem-utils \
 "
+
+# Default root password: oelinux123
+EXTRA_USERS_PARAMS = "usermod -p '\$6\$UDMimfYF\$akpHo9mLD4z0vQyKzYxYbsdYxnpUD7B7rHskq1E3zXK8ygxzq719wMxI78i0TIIE0NB1jUToeeFzWXVpBBjR8.' root;"
 
 # Adding kernel-devsrc to provide kernel development support on SDK
 TOOLCHAIN_TARGET_TASK += "kernel-devsrc"

--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -14,9 +14,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-qcom-utilities-filesystem-utils \
 "
 
-EXTRA_USERS_PARAMS = "\
-    useradd -r -s /bin/false system; \
-    "
-
 # Adding kernel-devsrc to provide kernel development support on SDK
 TOOLCHAIN_TARGET_TASK += "kernel-devsrc"


### PR DESCRIPTION
- System user is really legacy and shouldn't be used or required
- Make sure there is a default password for root and drop allow-empty-password and empty-root-password from image features