### PR TITLE
distro: rename distro name to qcom-distro

### DIFF
--- a/conf/distro/qcom-distro.conf
+++ b/conf/distro/qcom-distro.conf
@@ -3,6 +3,3 @@ require conf/distro/include/qcom-base.inc
 DISTRO_NAME = "QCOM Reference Distro with Wayland"
 
 DISTRO_FEATURES:append = " wayland x11 opengl vulkan"
-
-DISTROOVERRIDES = "qcom-wayland"
-


### PR DESCRIPTION
Rename default distro name from qcom to qcom-distro to avoid override confusion from the soc family override set in meta-qcom.

As 'qcom-distro' is a clean override, drop local 'qcom-wayland' replacement for the override, since there are no users for it.