### PR TITLE
qcom-base distro cleanups

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -23,7 +23,6 @@ PACKAGE_CLASSES = "package_ipk"
 IMAGE_FSTYPES:remove = "tar.gz"
 
 # Pull in the initrd image by default
-INITRAMFS_IMAGE_BUNDLE ?= "1"
 INITRAMFS_IMAGE = "initramfs-rootfs-image"
 
 INHERIT += "buildhistory"

--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -11,8 +11,6 @@ DISTRO_FEATURES:append = " bluetooth efi overlayfs pam pni-names ptest wifi"
 
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"
-VIRTUAL-RUNTIME_init_manager = "systemd"
-VIRTUAL-RUNTIME_dev_manager  = "udev"
 
 PACKAGECONFIG:append:pn-systemd = " resolved networkd"
 

--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -32,6 +32,7 @@ INHERIT += "recipe_sanity"
 BUILDHISTORY_COMMIT = "1"
 
 require conf/distro/include/security_flags.inc
+require conf/distro/include/yocto-space-optimize.inc
 require conf/distro/include/yocto-uninative.inc
 
 INHERIT += "uninative"

--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -7,10 +7,6 @@ SDK_VENDOR = "-qcomsdk"
 
 TARGET_VENDOR = "-qcom"
 
-# defaultsetup.inc gets includes after ${DISTRO}.conf, so we need to set it here
-# to make the python below work. Local, site and auto.conf will override it.
-TCMODE ?= "default"
-
 DISTRO_FEATURES:append = " bluetooth efi overlayfs pam pni-names ptest wifi"
 
 # Use systemd init manager for system initialization.

--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -12,8 +12,6 @@ DISTRO_FEATURES:append = " bluetooth efi overlayfs pam pni-names ptest wifi"
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"
 
-PACKAGECONFIG:append:pn-systemd = " resolved networkd"
-
 # Prepare a flat image directory structure suitable to flash with QDL
 IMAGE_CLASSES += "image_types_qcom"
 IMAGE_FSTYPES += "qcomflash"

--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -31,6 +31,7 @@ INHERIT += "recipe_sanity"
 
 BUILDHISTORY_COMMIT = "1"
 
+require conf/distro/include/security_flags.inc
 require conf/distro/include/yocto-uninative.inc
 
 INHERIT += "uninative"


### PR DESCRIPTION
* Remove settings that are not required or used
* Include security_flags and yocto-space-optimize from the oe-core