### PR TITLE
packagegroup-qcom-utilities: extend support-utils

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -29,5 +29,10 @@ RDEPENDS:${PN}-network-utils = " \
     "
 
 RDEPENDS:${PN}-support-utils = " \
+    file \
+    less \
+    ltrace \
     procps \
+    strace \
+    usbutils \
     "


### PR DESCRIPTION
Extend packagegroup-qcom-utilities-support-utils to include file, less, ltrace, strace and usbutils, for better user experience.