### PR TITLE
qcom-base: switch to glvnd implementation

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -42,5 +42,13 @@ PACKAGECONFIG:append:pn-mesa = " opencl libclc gallium-llvm"
 PACKAGECONFIG:append:pn-mesa-native = " opencl libclc gallium-llvm"
 PACKAGECONFIG:append:pn-nativesdk-mesa = " opencl libclc gallium-llvm"
 
+# Switch to GLVND wrapper
+PACKAGECONFIG:append:pn-mesa = " glvnd"
+PREFERRED_PROVIDER_virtual/egl = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgl = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgles1 = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgles2 = "libglvnd"
+PREFERRED_PROVIDER_virtual/libgles3 = "libglvnd"
+
 # Disable weston idle timeout
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"


### PR DESCRIPTION
GLVND is a mechanism to provide several OpenGL / GL ES / EGL implementations, allowing one to use the one which works on a particular platform. This follow the ideas of ICD (installable client drivers) as used by Vulkan and OpenCL.

Switch the distro to using GLVND in order to allow co-installing Mesa with other OpenGL implementations.