### PR TITLE
qcom-multimedia-image: Add packagegroup-qcom-test-pkgs to test QCOM image

### DIFF
--- a/recipes-crypto/libkcapi/libkcapi_%.bbappend
+++ b/recipes-crypto/libkcapi/libkcapi_%.bbappend
@@ -1,0 +1,2 @@
+# Enable testapp
+PACKAGECONFIG:append = " testapp"

--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -5,6 +5,7 @@ SUMMARY = "Basic Wayland image with Weston"
 IMAGE_FEATURES += "weston"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     weston \
     weston-examples \

--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Qualcomm test packagegroup"
+DESCRIPTION = "Package group to bring in packages required to test images"
+
+inherit packagegroup
+
+PACKAGES = "${PN}"
+
+RDEPENDS:${PN} = "\
+    igt-gpu-tools \
+    iperf3 \
+    libkcapi \
+    lmbench \
+    "

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -43,5 +43,6 @@ RDEPENDS:${PN}-support-utils = " \
     ltrace \
     procps \
     strace \
+    tinyalsa \
     usbutils \
     "


### PR DESCRIPTION
1. Add below utilities to packagegroup-qcom-test-pkgs.bb which will be used to test QCOM image and add the packagegroup packagegroup-qcom-test-pkgs to qcom-multimedia-image

- igt-gpu-tools ->will be used to test display
- iperf3 -> will be used for USB/PCIe
- libkcapi -> enable applications to utilize kernel-level cryptographic functionality
- lmbench -> It is a tool used for performance analysis
- tinyalsa -> tinyplay, tinycap will be used to test Audio playback and recording via USB headset


2. Enable testapp packageconfig for libkcapi to enable kcapi test program in libkcapi bbappend