### PR TITLE
layer.conf: mark qcom-distro as compatible with whinlatter release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,4 +18,4 @@ LAYERDEPENDS_qcom-distro = " \
     qcom \
     xfce-layer \
 "
-LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar"
+LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar whinlatter"


### PR DESCRIPTION
There are no breaking changes in the qcom-distro layer, so simply mark it as compatible with the next OE branch, whinlatter.