### PR TITLE
packagegroup-qcom-utilities: enable hostapd and trace-cmd

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -55,5 +55,6 @@ RDEPENDS:${PN}-support-utils = " \
     procps \
     strace \
     tinyalsa \
+    trace-cmd \
     usbutils \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -37,6 +37,7 @@ RRECOMMENDS:${PN}-gpu-utils = " \
 
 RDEPENDS:${PN}-network-utils = " \
     ethtool \
+    hostapd \
     iproute2 \
     iw \
     networkmanager \


### PR DESCRIPTION
- hostapd is added to support wireless access point functionality.
- trace-cmd is added to facilitate kernel tracing and diagnostics.