### PR TITLE
Add an image to showcase proprietary features

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -1,0 +1,9 @@
+require qcom-multimedia-image.bb
+
+SUMMARY = "An image built on top of multimedia image for proprietary features"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    iris-video-dlkm \
+    kgsl-dlkm \
+"
+


### PR DESCRIPTION
Add an image, qcom-multimedia-proprietary-image, to showcase capabilities that are either missing or not fully supported in upstream, in areas such as camera, display, GPU, video and other multimedia components.