### PR TITLE
packagegroup-qcom-test-pkgs: add igt-gpu-tools-tests package

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -6,7 +6,7 @@ inherit packagegroup
 PACKAGES = "${PN}"
 
 RDEPENDS:${PN} = "\
-    igt-gpu-tools \
+    igt-gpu-tools-tests \
     iperf3 \
     libkcapi \
     lmbench \


### PR DESCRIPTION
Add the igt-gpu-tools-tests package to enable support for DRM driver testing.

Fixes [issue#1000](https://github.com/qualcomm-linux/meta-qcom/issues/1000)