### PR TITLE
qcom-multimedia-image: Enable GStreamer support

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -5,21 +5,21 @@ SUMMARY = "Basic Wayland image with Weston"
 IMAGE_FEATURES += "weston"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'weston-xwayland xterm', '', d)} \
+    alsa-utils-alsatplg \
+    alsa-utils-alsaucm \
+    alsa-utils-aplay \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
+    pipewire \
+    pipewire-alsa \
+    pipewire-modules-meta \
+    pipewire-pulse \
+    pipewire-spa-tools \
+    pipewire-tools \
     weston \
     weston-examples \
     weston-init \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'weston-xwayland xterm', '', d)} \
-    alsa-utils-aplay \
-    alsa-utils-alsaucm \
-    alsa-utils-alsatplg \
-    pipewire \
-    pipewire-pulse \
-    pipewire-alsa \
-    pipewire-spa-tools \
-    pipewire-modules-meta \
-    pipewire-tools \
     wireplumber \
 "
 

--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -9,6 +9,10 @@ CORE_IMAGE_BASE_INSTALL += " \
     alsa-utils-alsatplg \
     alsa-utils-alsaucm \
     alsa-utils-aplay \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-good \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     pipewire \


### PR DESCRIPTION
Added the following recepies to multimedia-image to enable
    GStreamer framework and plugins
      gstreamer1.0
      gstreamer1.0-plugins-base
      gstreamer1.0-plugins-good
      gstreamer1.0-plugins-bad