### PR TITLE
packagegroup-qcom-test-pkgs: add more utilities

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -6,8 +6,14 @@ inherit packagegroup
 PACKAGES = "${PN}"
 
 RDEPENDS:${PN} = "\
+    fastrpc-tests \
     igt-gpu-tools-tests \
     iperf3 \
+    iproute2 \
     libkcapi \
     lmbench \
+    media-ctl \
+    pulseaudio-misc \
+    v4l-utils \
+    yavta \
     "


### PR DESCRIPTION
Add the following utilities in 'packagegroup-qcom-test-pkgs.bb'

- fastrpc-tests (used for fastrpc testing)
- iproute2 (used for validating network interfaces and routing)
- media-ctl, v4l-utils and yavta (used to test and debug V4L2 devices)
- pulseaudio-misc (used for validating audio functionality)