### PR TITLE
packagegroup-qcom-test-pkg: install fastrpc-tests only on aarch64 targets

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -1,12 +1,13 @@
 SUMMARY = "Qualcomm test packagegroup"
 DESCRIPTION = "Package group to bring in packages required to test images"
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 inherit packagegroup
 
 PACKAGES = "${PN}"
 
 RDEPENDS:${PN} = "\
-    fastrpc-tests \
     igt-gpu-tools-tests \
     iperf3 \
     iproute2 \
@@ -16,4 +17,8 @@ RDEPENDS:${PN} = "\
     pulseaudio-misc \
     v4l-utils \
     yavta \
+    "
+
+RDEPENDS:${PN}:append:aarch64 = " \
+    fastrpc-tests \
     "


### PR DESCRIPTION
fastrpc is only really tested on aarch64 targets, and tests package also includes pre-built libraries which are aarch64 specific.