### PR TITLE
qcom-distro: use opencl DISTRO_FEATURE

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -45,10 +45,5 @@ require conf/distro/include/yocto-uninative.inc
 
 INHERIT += "uninative"
 
-# Enable OpenCL
-PACKAGECONFIG:append:pn-mesa = " opencl libclc gallium-llvm"
-PACKAGECONFIG:append:pn-mesa-native = " opencl libclc gallium-llvm"
-PACKAGECONFIG:append:pn-nativesdk-mesa = " opencl libclc gallium-llvm"
-
 # Disable weston idle timeout
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"

--- a/conf/distro/qcom-distro.conf
+++ b/conf/distro/qcom-distro.conf
@@ -4,6 +4,7 @@ DISTRO_NAME = "QCOM Reference Distro with Wayland"
 
 DISTRO_FEATURES:append = " \
     glvnd \
+    opencl \
     opengl \
     vulkan \
     wayland \


### PR DESCRIPTION
Now as the OE-Core has introduced the 'opencl' DISTRO_FEATURE, stop manually enabling Mesa's OpenCL PACKAGECONFIG entries and simply enable the 'opencl' DISTRO_FEATURE.