### PR TITLE
Restrict qcom-multimedia-proprietary-image to aarch64 targets

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -2,6 +2,10 @@ require qcom-multimedia-image.bb
 
 SUMMARY = "An image built on top of multimedia image for proprietary features"
 
+# This image is compatible only with aarch64 (ARMv8)
+COMPATIBLE_MACHINE = "^$"
+COMPATIBLE_MACHINE:aarch64 = "(.*)"
+
 CORE_IMAGE_BASE_INSTALL += " \
     iris-video-dlkm \
     kgsl-dlkm \


### PR DESCRIPTION
The packages included in qcom-multimedia-proprietary-image are intended only for ARMv8 (aarch64) architectures. Add an explicit COMPATIBLE_MACHINE check to prevent this image from being built for unsupported architectures.