### PR TITLE
pipewire: Add pipewire user to 'kmem' group

### DIFF
--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -3,4 +3,9 @@ SYSTEMD_SERVICE:${PN}-pulse = "pipewire-pulse.service"
 SYSTEMD_AUTO_ENABLE:${PN}-pulse = "enable"
 SYSTEMD_PACKAGES += "${PN}-pulse"
 
+USERADD_PARAM:${PN} = "--system --home / --no-create-home \
+                       --comment 'PipeWire multimedia daemon' \
+                       --gid pipewire --groups audio,video,kmem \
+                       pipewire"
+
 FILES:${PN}-pulse += "${systemd_unitdir}/system-preset/98-pipewire-pulse.preset"


### PR DESCRIPTION
AudioReach requires access to /dev/dma_heap/system for buffer allocation via the DMA-BUF Heap interface. To enable this, the pipewire user is now added to the 'kmem' group through USERADD_PARAM.