### PR TITLE
Enable hardware watchdog support

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -20,6 +20,9 @@ DISTRO_FEATURES:append = " \
 # Use systemd init manager for system initialization.
 INIT_MANAGER = "systemd"
 
+# Activate systemd watchdog
+WATCHDOG_RUNTIME_SEC:pn-systemd = "30"
+
 # Prepare a flat image directory structure suitable to flash with QDL
 IMAGE_CLASSES += "image_types_qcom"
 IMAGE_FSTYPES += "qcomflash"


### PR DESCRIPTION
Enabling hardware watchdog is essential for collecting system dumps in case of hangs or crashes.

Set `WATCHDOG_RUNTIME_SEC` to 30 seconds for systemd recipe to ensure the `RuntimeWatchdogSec=` parameter in `/etc/systemd/system.conf` reflects this value, thereby activating the watchdog.

For implementation details of WATCHDOG_RUNTIME_SEC, refer to OE-Core revision: 1c61a1eb9c4faa9ab32b0440bbdd88c22c3cd945.