### PR TITLE
packagegroup-qcom-utilities: Add efivar utility

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -49,6 +49,7 @@ RDEPENDS:${PN}-network-utils = " \
     "
 
 RDEPENDS:${PN}-support-utils = " \
+    efivar \
     file \
     less \
     ltrace \


### PR DESCRIPTION
The efivar utility has been added to the package group for debugging purposes.

This tool is essential for debugging boot-related issues, managing secure boot configurations, and inspecting system firmware behavior on UEFI-enabled platforms.