### PR TITLE
packagegroup-qcom-test-pkg: add opencv-apps to test image

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -14,6 +14,7 @@ RDEPENDS:${PN} = "\
     libkcapi \
     lmbench \
     media-ctl \
+    opencv-apps \
     pulseaudio-misc \
     v4l-utils \
     yavta \


### PR DESCRIPTION
Integrating OpenCV libraries and its associated test binaries into the test image to ensure sanity of the OpenCV modules w.r.t functionality and Performance.