### PR TITLE
packagegroup-qcom-test-pkg: install opencv-apps only on aarch64 targets

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -14,7 +14,6 @@ RDEPENDS:${PN} = "\
     libkcapi \
     lmbench \
     media-ctl \
-    opencv-apps \
     pulseaudio-misc \
     v4l-utils \
     yavta \
@@ -22,4 +21,5 @@ RDEPENDS:${PN} = "\
 
 RDEPENDS:${PN}:append:aarch64 = " \
     fastrpc-tests \
+    opencv-apps \
     "


### PR DESCRIPTION
opencv-apps package is currently only used and tested on ARMv8 (aarch64) machines.