### PR TITLE
qcom-multimedia-image: enable libcamera support

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -13,6 +13,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
+    libcamera \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     pipewire \


### PR DESCRIPTION
- Include libcamera in the multimedia image to provide an open-source camera stack on Qualcomm platforms.
- This standardizes our camera bring-up and validation workflow using upstream components.

-  User-visible functionality: Enumerate and stream from supported `/dev/video*`devices: - `cam --list` - `cam -c <index> -s <WxH> -f <pixfmt> -o frame.yuv`