### PR TITLE
pg-qcom-utilities: support-utils: add dtc

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -49,6 +49,7 @@ RDEPENDS:${PN}-network-utils = " \
     "
 
 RDEPENDS:${PN}-support-utils = " \
+    dtc \
     efivar \
     file \
     less \


### PR DESCRIPTION
Add dtc to support-utils, useful for debugging runtime device-tree issues.