### PR TITLE
packagegroup-qcom-utilities: enable iperf2

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -46,6 +46,7 @@ RRECOMMENDS:${PN}-gpu-utils = " \
 RDEPENDS:${PN}-network-utils = " \
     ethtool \
     hostapd \
+    iperf2 \
     iproute2 \
     iw \
     networkmanager \


### PR DESCRIPTION
Enable iperf2 to support network performance testing. iperf2 is a widely used network performance testing tool that measures bandwidth, latency, jitter, and packet loss between two endpoints.