### PR TITLE
Enable systemd-growfs-root.service to resize rootfs

### DIFF
--- a/recipes-core/systemd/systemd/growfs-root.conf
+++ b/recipes-core/systemd/systemd/growfs-root.conf
@@ -1,0 +1,5 @@
+[Service]
+ExecStartPost=/bin/systemctl disable systemd-growfs-root.service
+
+[Install]
+WantedBy=basic.target

--- a/recipes-core/systemd/systemd/growfs-root.preset
+++ b/recipes-core/systemd/systemd/growfs-root.preset
@@ -1,0 +1,1 @@
+enable systemd-growfs-root.service

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,3 +1,17 @@
+# Enable systemd-grow-rootfs.service to resize root filesystem at boot
+FILESEXTRAPATHS:append := "${THISDIR}/${BPN}:"
+SRC_URI += "\
+    file://growfs-root.conf \
+    file://growfs-root.preset \
+"
+
+do_install:append:qcom() {
+    install -Dm 0644 ${WORKDIR}/sources/growfs-root.preset \
+            ${D}${systemd_unitdir}/system-preset/98-growfs-root.preset
+    install -Dm 0644 ${WORKDIR}/sources/growfs-root.conf \
+            ${D}${systemd_unitdir}/system/systemd-growfs-root.service.d/growfs-root.conf
+}
+
 # This disables the 'mac' policy for pni-names
 # We do not want MAC address based naming, for example the wifi on RB1
 # gets a new MAC address every boot *and* doesn't support any of the


### PR DESCRIPTION
Using `systemd-growfs-root.service` rootfs can resized to utilize the
full available disk space. Enable it using a  drop-in config and a preset file.