### PR TITLE
packagegroup-qcom-test-pkgs: add more utilities

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -8,6 +8,8 @@ inherit packagegroup
 PACKAGES = "${PN}"
 
 RDEPENDS:${PN} = "\
+    coreutils \
+    expect \
     igt-gpu-tools-tests \
     iperf3 \
     iproute2 \
@@ -15,7 +17,10 @@ RDEPENDS:${PN} = "\
     lmbench \
     media-ctl \
     opencv-apps \
+    openssh-sftp-server \
     pulseaudio-misc \
+    rng-tools \
+    util-linux \
     v4l-utils \
     yavta \
     "


### PR DESCRIPTION
Add the following utilities in 'packagegroup-qcom-test-pkgs.bb'.

- coreutils (for essential GNU command-line utilities)
- expect (for automating interactive applications according to a script and for testing applications)
- openssh-sftp-server (required for scp to work as it uses SFTP protocol for file transfer)
- rng-tools (for cryptography, secure communications, and randomness)
- util-linux (provides essential utilities for managing Linux systems like fdisk, blkid, kill, login, dmesg etc)

Fixes [issue#1190](https://github.com/qualcomm-linux/meta-qcom/issues/1190)