### PR TITLE
distro: add KVM-specific distro config to enable virtualization features

### DIFF
--- a/conf/distro/qcom-distro-kvm.conf
+++ b/conf/distro/qcom-distro-kvm.conf
@@ -1,0 +1,6 @@
+require conf/distro/include/qcom-distro.conf
+
+DISTRO_FEATURES:append = " \
+    kvm \
+    virtualization \
+"


### PR DESCRIPTION
Solve the lack of a mechanism to toggle between Gunyah and KVM during the build process, which makes it difficult to selectively enable virtualization features for KVM-based targets. Add `conf/distro/qcom-distro-kvm.conf` to append "virtualization kvm" to DISTRO_FEATURES and include `qcom-distro.conf` as the base, providing a clear and maintainable way to enable KVM support at the distro level.

Fixes qualcomm-linux/meta-qcom#1154