### PR TITLE
Audioreach migration

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,6 +19,6 @@ LAYERDEPENDS_qcom-distro = " \
     xfce-layer \
 "
 LAYERRECOMMENDS_qcom-distro = " \
-    meta-ar \
+    meta-audioreach \
 "
 LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar whinlatter"

--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -12,5 +12,5 @@ CORE_IMAGE_BASE_INSTALL += " \
     qcom-adreno \
 "
 CORE_IMAGE_BASE_INSTALL:append = " \
-    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-ar', ' packagegroup-qcom-audio', '', d)} \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', ' packagegroup-audioreach', '', d)} \
 "


### PR DESCRIPTION
The meta-ar layer has been deprecated and replaced by meta-audioreach
Replace meta-ar with meta-audioreach in LAYERRECOMMENDS_qcom-distro within layer.conf
Update qcom-multimedia-proprietary-image.bb to check for meta-audioreach and use packagegroup-audioreach instead of packagegroup-qcom-audio
