### PR TITLE
qcom-distro-kvm.conf: fix require path

### DIFF
--- a/conf/distro/qcom-distro-kvm.conf
+++ b/conf/distro/qcom-distro-kvm.conf
@@ -1,4 +1,4 @@
-require conf/distro/include/qcom-distro.conf
+require conf/distro/qcom-distro.conf
 
 DISTRO_FEATURES:append = " \
     kvm \


### PR DESCRIPTION
A non-existant file path was used leading to build error when qcom-distro-kvm was used. Correct it to make use of right path.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/1154