### PR TITLE
Add irqbalance service to packagegroup-qcom

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -67,4 +67,5 @@ RDEPENDS:${PN}-support-utils = " \
     tinyalsa \
     trace-cmd \
     usbutils \
+    irqbalance \
     "


### PR DESCRIPTION
irqbalance distributes hardware interrupts across processors to improve system performance.