### PR TITLE
qcom-multimedia-image: add packagegroup-container for Docker support

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -14,6 +14,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     libcamera \
+    packagegroup-container \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     pipewire \


### PR DESCRIPTION
Need Docker support enabled on the platform to facilitate:
  Intelligent Multimedia Software Development Kit (IMSDK) in a Docker container.
  Multiple reference solutions using microservices deployed across multiple Docker containers.

The 'packagegroup-container' is part of the meta-virtualization layer.