### PR TITLE
packagegroup-qcom-utilities: enable net-tools

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -49,6 +49,7 @@ RDEPENDS:${PN}-network-utils = " \
     iperf2 \
     iproute2 \
     iw \
+    net-tools \
     networkmanager \
     openssh-scp \
     openssh-ssh \


### PR DESCRIPTION
net-tools is a legacy Linux package that provides fundamental networking utilities, including commands such as ifconfig, netstat, arp, and route. Network configuration and testing both rely on these tools.