### PR TITLE
systemd bbappend: remove MAC-policy override, oe-core has been fixed

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -12,12 +12,3 @@ do_install:append:qcom() {
             ${D}${systemd_unitdir}/system/systemd-growfs-root.service.d/growfs-root.conf
 }
 
-# This disables the 'mac' policy for pni-names
-# We do not want MAC address based naming, for example the wifi on RB1
-# gets a new MAC address every boot *and* doesn't support any of the
-# naming features. This leads to a new, unpredictable interface name on
-# every boot
-
-do_install:append:qcom() {
-	sed -i -e 's: mac::g' ${D}${nonarch_libdir}/systemd/network/99-default.link
-} 


### PR DESCRIPTION
This bbappend disabled the MAC renaming policy, upstream openembedded-core has disabled it by default now:

https://github.com/openembedded/openembedded-core/commit/9b34a810496f4b769394aa6ba7c0f6013d18ccc8