### PR TITLE
receipe-connectivity: bluez5: install essential bluetooth-tools

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -1,0 +1,20 @@
+#Include and install bluetooth tools which are required.
+
+# Include only desired tools that are conditional on READLINE in bluez
+INST_TOOLS_READLINE = " \
+    tools/bluetooth-player \
+    tools/obexctl \
+    tools/btmgmt \
+"
+
+# Remove desired tools from noinst-tools
+NOINST_TOOLS:remove:qcom = " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'readline', '${INST_TOOLS_READLINE}', '', d)} \
+"
+
+do_install:append:qcom() {
+    # Install desired tools that upstream leaves in build area
+    for f in ${INST_TOOLS_READLINE} ; do
+        install -m 755 ${B}/$f ${D}/${bindir}
+    done
+}


### PR DESCRIPTION
Upstream builds several readline-based tools (bluetooth-player, obexctl, btmgmt) but leaves them in the build directory as noinst tools. Make these available in the target rootfs when readline support is enabled by moving them out of NOINST_TOOLS and explicitly installing them into ${bindir} for qcom machines.