### PR TITLE
qcom-console-image: disable package-management when using sota

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -2,7 +2,8 @@ require qcom-minimal-image.bb
 
 SUMMARY = "Basic console image"
 
-IMAGE_FEATURES += "package-management ssh-server-openssh"
+IMAGE_FEATURES += "${@bb.utils.contains('DISTRO_FEATURES', 'sota', '', 'package-management', d)} \
+                   ssh-server-openssh"
 
 CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-qcom-utilities-debug-utils \


### PR DESCRIPTION
The sota distro feature implies ostree-based system management, where the root filesystem is immutable and package operations are not supported. In this model, updates are delivered exclusively through ostree, so the traditional package-management image feature has no use.

Update the image definition to add package-management only when sota is not enabled in DISTRO_FEATURES.