### PR TITLE
wireplumber: Enable bluez plugin.

### DIFF
--- a/recipes-multimedia/audio/wireplumber_%.bbappend
+++ b/recipes-multimedia/audio/wireplumber_%.bbappend
@@ -1,3 +1,9 @@
+do_install:append:qcom () {
+  install -v -m 0644 \
+      ${S}/src/config/wireplumber.conf.d.examples/bluetooth.conf \
+      ${D}${datadir}/wireplumber/wireplumber.conf.d/
+}
+
 # Enable wireplumber as a system-wide service
 SYSTEMD_SERVICE:${PN} = "wireplumber.service"
 SYSTEMD_AUTO_ENABLE:${PN} = "enable"


### PR DESCRIPTION
The BlueZ monitors are integrated with logind to
ensure that only one user at a time can use the
Bluetooth audio devices.on QLI devices, there is
no user login sessions enabled. so disable this
feature will allow bluez plugin to launch without
looking for logind session.

Add bluetooth configuration file in wireplumber
delta conf folder for user preferred configuration.