### PR TITLE
qcom-minimal-image: include resize-rootfs for rootfs expansion

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -12,6 +12,7 @@ REQUIRED_DISTRO_FEATURES = "pam systemd"
 CORE_IMAGE_BASE_INSTALL += " \
     kernel-modules \
     packagegroup-qcom-utilities-filesystem-utils \
+    rootfs-resize \
 "
 
 # Default root password: oelinux123


### PR DESCRIPTION
By default, the root filesystem is generated with a minimal size to support flashing across multiple boards. The resize-rootfs recipe installs a systemd fragment that automatically resizes the rootfs on first boot to utilize the full available disk space. Add this recipe to qcom-minimal-image for increasing rootfs size.