### PR TITLE
Add sysbench and tiobench to profile-utils package group.

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -61,7 +61,9 @@ RDEPENDS:${PN}-network-utils = " \
 RDEPENDS:${PN}-profile-utils = " \
     perf \
     powertop \
+    sysbench \
     systemd-analyze \
+    tiobench \
     "
 
 RDEPENDS:${PN}-support-utils = " \


### PR DESCRIPTION
Extend the profile-utils packagegroup to include sysbench and tiobench for benchmarking system and I/O performance.