### PR TITLE
Fix a typo in package name used in qcom-minimal-image.bb

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -12,7 +12,7 @@ REQUIRED_DISTRO_FEATURES = "pam systemd"
 CORE_IMAGE_BASE_INSTALL += " \
     kernel-modules \
     packagegroup-qcom-utilities-filesystem-utils \
-    rootfs-resize \
+    resize-rootfs \
 "
 
 # Default root password: oelinux123


### PR DESCRIPTION
Correct the package name from `rootfs-resize` to `resize-rootfs` in qcom-minimal-image.bb to match the actual recipe name.