### PR TITLE
qcom-multimedia-image: enable docker-compose

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -9,6 +9,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     alsa-utils-alsatplg \
     alsa-utils-alsaucm \
     alsa-utils-aplay \
+    docker-compose \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \


### PR DESCRIPTION
Enable Docker Compose on the platform to orchestrate multi-container workloads:
  - Run IMSDK inside a container with Compose-managed dependencies.
  - Deploy reference microservice solutions across multiple containers using a single Compose file.

'docker-compose' is provided by meta-virtualization layer.