### PR TITLE
qcom-multimedia-image: add libdrm-tests for the 'modeset' util

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -15,6 +15,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     libcamera \
+    libdrm-tests \
     packagegroup-container \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \


### PR DESCRIPTION
The 'modeset' utility was requested to be able to have the CI run display and modesetting smoke tests.