### PR TITLE
qcom-console-image: build pg-qcom-virtualization conditionally

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -10,7 +10,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-qcom-utilities-network-utils \
     packagegroup-qcom-utilities-profile-utils \
     packagegroup-qcom-utilities-support-utils \
-    packagegroup-qcom-virtualization \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'packagegroup-qcom-virtualization', '', d)} \
 "
 
 CORE_IMAGE_EXTRA_INSTALL += " \


### PR DESCRIPTION
Only include packagegroup-qcom-virtualization if 'virtualization' is available in DISTRO_FEATURES (e.g. used with qcom-distro-kvm).