### PR TITLE
libvirt: temporarily set -W=no-deprecated-declarations

### DIFF
--- a/recipes-extended/libvirt/libvirt_git.bbappend
+++ b/recipes-extended/libvirt/libvirt_git.bbappend
@@ -1,0 +1,3 @@
+# Temporarily disable warnings due deprecated libxml2 APIs until the proper fix
+# gets backported and merged in meta-virtualization
+CFLAGS:append:qcom = " -Wno-deprecated-declarations"


### PR DESCRIPTION
Temporarily disable warnings due deprecated libxml2 APIs until the proper fix gets backported and merged in meta-virtualization.

https://lists.yoctoproject.org/g/meta-virtualization/message/9476