### PR TITLE
pg-qcom-utilities: support-utils: add udev-extraconf-automount

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -75,5 +75,6 @@ RDEPENDS:${PN}-support-utils = " \
     procps \
     tinyalsa \
     trace-cmd \
+    udev-extraconf-automount \
     usbutils \
     "


### PR DESCRIPTION
udev-extraconf in oe-core provides additional configuration files and scripts for the udev device manager. Add udev-extraconf-automount package to support utils, to automount storage devices on the target.