### PR TITLE
qcom-multimedia-image: enable K8s and container runtime

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -14,8 +14,13 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
+    kubeadm \
+    kubernetes \
+    kubernetes-misc \
     libcamera \
     packagegroup-container \
+    packagegroup-containerd \
+    packagegroup-oci \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     pipewire \


### PR DESCRIPTION
Enable Kubernetes on the platform to orchestrate containerized workloads:
  - Added kubeadm, kubernetes, and kubernetes-misc for cluster bootstrap.
  - Included packagegroup-containerd and packagegroup-oci to provide a CRI-compliant runtime.

All added packages are provided by meta-virtualization layer.