### PR TITLE
nerdctl: unbreak the CI

### DIFF
--- a/recipes-containers/nerdctl/nerdctl_%.bbappend
+++ b/recipes-containers/nerdctl/nerdctl_%.bbappend
@@ -1,0 +1,7 @@
+INSANE_SKIP:${PN}:arm:qcom-distro += "textrel"
+
+
+# workaround for permissions preventing rm_work to succeed
+do_rm_work:prepend:qcom-distro() {
+    chmod u+w ${UNPACKDIR} -R
+}


### PR DESCRIPTION
Recent changes to nerdctl broke the builds. While Bruce is working on the fixes, workaround the issues locally.

See https://lists.yoctoproject.org/g/meta-virtualization/topic/nerdctl_fails_in_rm_work/116966533