### PR TITLE
nerdctl: fix the workaround

### DIFF
--- a/recipes-containers/nerdctl/nerdctl_%.bbappend
+++ b/recipes-containers/nerdctl/nerdctl_%.bbappend
@@ -3,5 +3,7 @@ INSANE_SKIP:${PN}:arm:qcom-distro += "textrel"
 
 # workaround for permissions preventing rm_work to succeed
 do_rm_work:prepend:qcom-distro() {
-    chmod u+w ${UNPACKDIR} -R
+    if [ -d ${UNPACKDIR} ] ; then
+        chmod u+w ${UNPACKDIR} -R
+    fi
 }


### PR DESCRIPTION
Don't try chmod'ding ${UNPACKDIR} if it doesn't exist.