### PR TITLE
nerdctl: also apply the textrel workaround to qcom-distro-sota

### DIFF
--- a/recipes-containers/nerdctl/nerdctl_%.bbappend
+++ b/recipes-containers/nerdctl/nerdctl_%.bbappend
@@ -1,5 +1,5 @@
 INSANE_SKIP:${PN}:arm:qcom-distro += "textrel"
-
+INSANE_SKIP:${PN}:arm:qcom-distro-sota += "textrel"
 
 # workaround for permissions preventing rm_work to succeed
 do_rm_work:prepend:qcom-distro() {


### PR DESCRIPTION
The SOTA version of qcom-distro doesn't use qcom-distro overrides. Specify a separate override for it.