### PR TITLE
nerdctl: also apply the chmod workaround to qcom-distro-sota

### DIFF
--- a/recipes-containers/nerdctl/nerdctl_%.bbappend
+++ b/recipes-containers/nerdctl/nerdctl_%.bbappend
@@ -7,3 +7,9 @@ do_rm_work:prepend:qcom-distro() {
         chmod u+w ${UNPACKDIR} -R
     fi
 }
+
+do_rm_work:prepend:qcom-distro-sota() {
+    if [ -d ${UNPACKDIR} ] ; then
+        chmod u+w ${UNPACKDIR} -R
+    fi
+}


### PR DESCRIPTION
The SOTA version of qcom-distro doesn't use qcom-distro overrides. Specify a separate override for it.