### PR TITLE
Add qcom-container-orchestration-image for Kubernetes and container runtimes

### DIFF
--- a/conf/distro/qcom-distro-container-orchestration.conf
+++ b/conf/distro/qcom-distro-container-orchestration.conf
@@ -1,0 +1,7 @@
+require conf/distro/qcom-distro.conf
+
+DISTRO_FEATURES:append = " \
+    virtualization \
+"
+
+DISTRO_NAME:append = " (container-orchestration-enabled)"

--- a/recipes-products/images/qcom-container-orchestration-image.bb
+++ b/recipes-products/images/qcom-container-orchestration-image.bb
@@ -1,0 +1,13 @@
+require qcom-multimedia-proprietary-image.bb
+
+SUMMARY += "(with container orchestration)"
+
+REQUIRED_DISTRO_FEATURES += "virtualization"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    kubeadm \
+    kubernetes \
+    kubernetes-misc \
+    packagegroup-containerd \
+    packagegroup-oci \
+"


### PR DESCRIPTION
`qcom-container-orchestration-image` builds on top of 
`qcom-multimedia-proprietary-image` to provide an environment
for validating container orchestration stacks on Qualcomm Linux.
