### PR TITLE
nerdctl: more workarounds for the package build

### DIFF
--- a/recipes-containers/nerdctl/nerdctl_%.bbappend
+++ b/recipes-containers/nerdctl/nerdctl_%.bbappend
@@ -1,5 +1,6 @@
-INSANE_SKIP:${PN}:arm:qcom-distro += "textrel"
-INSANE_SKIP:${PN}:arm:qcom-distro-sota += "textrel"
+# Go binaries on ARMv7 are built in a strange way
+INSANE_SKIP:${PN}:append:arm:qcom-distro = " textrel"
+INSANE_SKIP:${PN}:append:arm:qcom-distro-sota = " textrel"
 
 # workaround for permissions preventing rm_work to succeed
 do_rm_work:prepend:qcom-distro() {


### PR DESCRIPTION
Our local workarounds ended up overriwriting INSAKE_SKIP for nerdctl on
ARMv7, which in turn caused QA errors which are already handled in
meta-virtualization. Use :append instead of extending the INSANE_SKIP.