### PR TITLE
qcom-distro-sota: Enable OSTree repo tarball generation for SOTA builds

### DIFF
--- a/conf/distro/qcom-distro-sota.conf
+++ b/conf/distro/qcom-distro-sota.conf
@@ -4,3 +4,6 @@ require conf/distro/sota.conf.inc
 INITRAMFS_IMAGE = "initramfs-ostree-image"
 
 DISTRO_NAME:append = " (OTA-enabled)"
+
+# Generate an OSTree repository tarball during image build
+BUILD_OSTREE_REPO_TARBALL = "1"


### PR DESCRIPTION
Set BUILD_OSTREE_REPO_TARBALL = "1" in qcom-distro-sota.conf to ensure an OSTree repository tarball is generated during image builds. This enhancement supports OTA workflows by providing a portable tarball of the OSTree repo alongside the image artifacts.