### PR TITLE
qcom-multimedia-proprietary-image: Enable sensor support

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -11,6 +11,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     iris-video-dlkm \
     kgsl-dlkm \
     qcom-adreno \
+    qcom-sensors-binaries \
 "
 CORE_IMAGE_BASE_INSTALL:append = " \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', ' packagegroup-audioreach', '', d)} \


### PR DESCRIPTION
- Include Sensing Hub in the multimedia image to allow users and clients to access sensor data from the Sensing Hub.
- Include qcom-sensors-binaries in the multimedia image, which provides prebuilt core binaries for accessing sensor streaming data.
- These binaries also include test applications that help validate sensor functionality through the Sensing Hub interface.