### PR TITLE
libcamera: change override from qcom to qcom-distro

### DIFF
--- a/recipes-multimedia/libcamera/libcamera_%.bbappend
+++ b/recipes-multimedia/libcamera/libcamera_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG:append:qcom = " gst"
+PACKAGECONFIG:append:qcom-distro = " gst"


### PR DESCRIPTION
Enable gst plugins when using one of qcom distros.