### PR TITLE
 Conditionally enable virtualization packages in qcom-multimedia-image

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -9,14 +9,14 @@ CORE_IMAGE_BASE_INSTALL += " \
     alsa-utils-alsatplg \
     alsa-utils-alsaucm \
     alsa-utils-aplay \
-    docker-compose \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'docker-compose', '', d)} \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     libcamera \
     libdrm-tests \
-    packagegroup-container \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'packagegroup-container', '', d)} \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     pipewire \


### PR DESCRIPTION
Guard packages provided by meta-virtualization layer with `virtualization`
DISTRO_FEATURE so they are omitted when users disable virtualization,
preventing unnecessary dependencies from being pulled into the image.

