### PR TITLE
qcom-multimedia-image:include libcamera-gst in image

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -15,6 +15,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
     libcamera \
+    libcamera-gst \
     libdrm-tests \
     packagegroup-container \
     packagegroup-qcom-test-pkgs \


### PR DESCRIPTION
Adds the libcamera-gst package to enable GStreamer plugins for libcamera in the qcom multimedia image.

