### PR TITLE
layer.conf: include selinux layer as dependency

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -16,6 +16,7 @@ LAYERDEPENDS_qcom-distro = " \
     networking-layer \
     openembedded-layer \
     qcom \
+    selinux \
     sota \
     virtualization-layer \
     xfce-layer \


### PR DESCRIPTION
Mark meta-selinux as a dependency so qcom-distro with SELinux configuration works.