### PR TITLE
qcom-base: switch package class to rpm

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -34,7 +34,7 @@ IMAGE_CLASSES += "image_types_qcom"
 IMAGE_FSTYPES += "qcomflash"
 
 # Set a default package class to avoid surprises
-PACKAGE_CLASSES = "package_ipk"
+PACKAGE_CLASSES = "package_rpm"
 
 # Avoid to duplicate the rootfs tarball by generating both tar.gz/tar.xz
 IMAGE_FSTYPES:remove = "tar.gz"


### PR DESCRIPTION
opkg/ipk has been causing frequent failures in CI due to intermittent libsolv crashes (see Yocto bug [1]) while generating the rootfs image. The issue is hard to reproduce and isolate, and the CI instability is blocking our testing efforts.

As a temporary workaround, switch the default PACKAGE_CLASSES to package_rpm, which is the package format more widely used and tested by Poky.

[1] https://bugzilla.yoctoproject.org/show_bug.cgi?id=16010