### PR TITLE
lxc: set DEBUG_PREFIX_MAP in TARGET_LDFLAGS for reproducibility

### DIFF
--- a/recipes-containers/lxc/lxc_%.bbappend
+++ b/recipes-containers/lxc/lxc_%.bbappend
@@ -1,0 +1,2 @@
+# https://lists.yoctoproject.org/g/meta-virtualization/message/9553
+TARGET_LDFLAGS:append:qcom-distro = " ${DEBUG_PREFIX_MAP}"


### PR DESCRIPTION
oe-core [1] removed DEBUG_PREFIX_MAP from TARGET_LDFLAGS to avoid passing prefix-map options via the linker flags.

Restore DEBUG_PREFIX_MAP in TARGET_LDFLAGS temporarily as a bbappend until https://lists.yoctoproject.org/g/meta-virtualization/message/9553 gets merged upstream.

[1]
https://git.openembedded.org/openembedded-core/commit/?id=1797741aad02b8bf429fac4b81e30cdda64b5448