### PR TITLE
qcom-multimedia-proprietary-image: Add libdiag-bin

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -13,6 +13,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     camx-nhx \
     iris-video-dlkm \
     kgsl-dlkm \
+    libdiag-bin \
     qcom-adreno \
     qcom-sensors-binaries \
 "


### PR DESCRIPTION
Add libdiag diagnostic utility binaries to enable diagnostic tools on the target system.