### PR TITLE
Update distro name to align with 1.x releases

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -1,4 +1,4 @@
-DISTRO_NAME = "QCOM Reference Distro with Wayland"
+DISTRO_NAME = "Qualcomm Linux Reference Distro"
 
 DISTRO_VERSION = "2.0"
 


### PR DESCRIPTION
All QLI documentation assumes that when users run `uname -a` on a device,
the OS name appears as "Qualcomm Linux" and the version follows the
"X.X-ver a.b" format. This convention helps users easily identify the
currently flashed build and verify successful OTA upgrades.
    
To preserve this expectation, the DISTRO_NAME should remain the same when
upgrading from QLI 1.x to QLI 2.0.