### PR TITLE
Revert "lxc: set DEBUG_PREFIX_MAP in TARGET_LDFLAGS for reproducibility"

### DIFF
--- a/recipes-containers/lxc/lxc_%.bbappend
+++ b/recipes-containers/lxc/lxc_%.bbappend
@@ -1,2 +1,0 @@
-# https://lists.yoctoproject.org/g/meta-virtualization/message/9553
-TARGET_LDFLAGS:append:qcom-distro = " ${DEBUG_PREFIX_MAP}"


### PR DESCRIPTION
This reverts commit 8041767c554bce613da6f7787aba975b4211bcc2.

Fix now available via meta-virtualization [1].

[1]
https://git.yoctoproject.org/meta-virtualization/commit/?id=4ed680e32e3670a4e50038387572ee7a35374c0e