### PR TITLE
qcom-minimal-image: disable systemd-networkd

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -33,3 +33,5 @@ python __anonymous() {
     if qcom_dtb_default == "multi-dtb":
         d.setVar("KERNEL_DEVICETREE", "")
 }
+
+BAD_RECOMMENDATIONS += "systemd-networkd"


### PR DESCRIPTION
Most contemporary Linux systems typically use either systemd-networkd or NetworkManager. Having both enabled can lead to timeouts, as both  NetworkManager-wait-online.service and systemd-networkd-wait-online.service wait for the network to be up.

This configuration often results in long boot delays when one service blocks waiting for an interface that the other is managing.

Remove systemd-networkd from the default systemd PACKAGECONFIG by marking it as a bad recommendation.

CRs-Fixed: 4426645