### PR TITLE
packagegroup-qcom-test-pkg: add fastcv-apps pkg to test image

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -27,4 +27,5 @@ RDEPENDS:${PN} = "\
 
 RDEPENDS:${PN}:append:aarch64 = " \
     fastrpc-tests \
+    fastcv-apps \
     "


### PR DESCRIPTION
Include fastcv-apps as a sample bin in the test image to test fastcv functionality

