### PR TITLE
Set SELinux DEFAULT_ENFORCING to permissive

### DIFF
--- a/conf/distro/include/qcom-distro-selinux.inc
+++ b/conf/distro/include/qcom-distro-selinux.inc
@@ -4,6 +4,8 @@ DISTRO_FEATURES_FILTER_NATIVESDK:append = " selinux"
 
 DISTRO_EXTRA_RDEPENDS:append = " packagegroup-core-selinux"
 
+DEFAULT_ENFORCING ?= "permissive"
+
 IMAGE_CLASSES += "selinux-image"
 
 DISTRO_NAME:append = " (SELinux-enabled)"


### PR DESCRIPTION
SELinux policies for QLI packages are still evolving and often require 
refinement as new features and changes are introduced. Setting the 
default SELinux enforcement level to 'permissive' helps surface policy
gaps and AVC denials without blocking functional bring-up.

This can be switched to 'enforcing' once the distribution reaches full
maturity and SELinux policies stabilize.