### PR TITLE
gst-plugins-imsdk: Enable TensorFlow Lite plugin

### DIFF
--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_%.bbappend
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append = " tflite"


### PR DESCRIPTION
Enable the tflite GStreamer plugin in IMSDK by appending the option to PACKAGECONFIG through a .bbappend.