### PR TITLE
qcom-multimedia-proprietary-image: add camera-service

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -7,6 +7,7 @@ COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE:aarch64 = "(.*)"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    camera-service \
     camx-dlkm \
     camx-kodiak \
     camx-lemans \


### PR DESCRIPTION
- Integrates camera-service into the multimedia prop image.
- Provides camera functionality for applications requiring image and video capture.
- Expands multimedia capabilities by enabling camera-related services in the build.