### PR TITLE
Blacklist upstream video drivers in qcom-multimedia-proprietary-image

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -13,6 +13,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     camx-nhx \
     camx-talos \
     iris-video-dlkm \
+    iris-video-dlkm-blacklist \
     kgsl-dlkm \
     libdiag-bin \
     qcom-adreno \


### PR DESCRIPTION
Add the iris-video-dlkm-blacklist package to the qcom-multimedia-proprietary-image
to prevent upstream video kernel modules from being loaded by default. This ensures
that only downstream multimedia drivers are exercised when validating the proprietary image.