### PR TITLE
Revert "qcom-multimedia-image: Add gst-plugins-imsdk"

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -10,7 +10,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     alsa-utils-alsaucm \
     alsa-utils-aplay \
     ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'docker-compose', '', d)} \
-    gst-plugins-imsdk-oss-meta \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \

--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -12,7 +12,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     camx-lemans \
     camx-nhx \
     camx-talos \
-    gst-plugins-imsdk \
     iris-video-dlkm \
     kgsl-dlkm \
     libdiag-bin \


### PR DESCRIPTION
Reverts qualcomm-linux/meta-qcom-distro#149, it broke qcom-armv7a builds with:

ERROR: Nothing RPROVIDES 'gst-plugins-imsdk-oss-meta' (but /work/build/../meta-qcom-distro/recipes-products/images/qcom-multimedia-image.bb RDEPENDS on or otherwise requires it)\n", 'gst-plugins-imsdk RPROVIDES gst-plugins-imsdk-oss-meta but was skipped: incompatible with machine qcom-armv7a (not in COMPATIBLE_MACHINE)\n', "ERROR: Required build target 'qcom-multimedia-image' has no buildable providers.\n", "Missing or unbuildable dependency chain was: ['qcom-multimedia-image', 'gst-plugins-imsdk-oss-meta

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
