### PR TITLE
qcom-distro: add tpm layer to dependencies

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,6 +18,7 @@ LAYERDEPENDS_qcom-distro = " \
     qcom \
     selinux \
     sota \
+    tpm-layer \
     virtualization-layer \
     xfce-layer \
 "


### PR DESCRIPTION
The qcom-distro layer pulls in TPM packages, so it should depend on the tpm-layer.

Fixes: 71cd2b3f483a ("packagegroup-qcom-security: include TPM2 tooling for TPM-enabled builds")