### PR TITLE
qcom-multimedia-image: Enable sensors support

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -26,6 +26,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     pipewire-pulse \
     pipewire-spa-tools \
     pipewire-tools \
+    qcom-sensors-binaries \
     userspace-resource-manager \
     weston \
     weston-examples \

--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -16,7 +16,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     kgsl-dlkm \
     libdiag-bin \
     qcom-adreno \
-    qcom-sensors-binaries \
 "
 CORE_IMAGE_BASE_INSTALL:append = " \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', ' packagegroup-audioreach', '', d)} \


### PR DESCRIPTION
Port sensors support from qcom-multimedia-proprietary-image to qcom-multimedia image