### PR TITLE
pipewire: don't override SYSTEMD_PACKAGES variable

### DIFF
--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,6 +1,6 @@
 # Enable pipewire-pulse as a system-wide service
 SYSTEMD_SERVICE:${PN}-pulse:qcom-distro = "pipewire-pulse.service"
 SYSTEMD_AUTO_ENABLE:${PN}-pulse:qcom-distro = "enable"
-SYSTEMD_PACKAGES:qcom-distro += "${PN}-pulse"
+SYSTEMD_PACKAGES:append:qcom-distro = " ${PN}-pulse"
 
 FILES:${PN}-pulse:append:qcom-distro = " ${systemd_unitdir}/system-preset/98-pipewire-pulse.preset"


### PR DESCRIPTION
The commit f227fcfc676f ("pipewire: put changes under distro overrides") ended up overriding the value of the SYSTEMD_PACKAGES rather than appending to it. This results in pipewire daemon not starting properly and, thus, broken audio.

Fixes: f227fcfc676f ("pipewire: put changes under distro overrides")
Reported-by: Nicolas Dechesne <nicolas.dechesne@oss.qualcomm.com>