### PR TITLE
qcom-minimal-image: disable KERNEL_DEVICETREE when using multi-dtb

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -25,3 +25,11 @@ TOOLCHAIN_TARGET_TASK += "kernel-devsrc"
 # Add RT tools only if the RT kernel is selected
 CORE_IMAGE_EXTRA_INSTALL += "${@bb.utils.contains_any('PREFERRED_PROVIDER_virtual/kernel', \
                             'linux-qcom-rt linux-qcom-next-rt', 'rt-tests', '', d)}"
+
+# UKI workaround for targets using multi-dtb (dtb provided by the firmware)
+## To be removed once https://lists.openembedded.org/g/openembedded-core/message/231436 is accepted
+python __anonymous() {
+    qcom_dtb_default = d.getVar("QCOM_DTB_DEFAULT")
+    if qcom_dtb_default == "multi-dtb":
+        d.setVar("KERNEL_DEVICETREE", "")
+}


### PR DESCRIPTION
When QCOM_DTB_DEFAULT is set to multi-dtb, the DTB is expected to be provided by the firmware (supporting base dtbs and dtbos), but uki.bbclass still consumes KERNEL_DEVICETREE during image generation (enabled via IMAGE_CLASSES), causing an inclusion of all dtbs and dtbos set by the target machine, invalidating the DTB provided by the firmware during boot.

Since uki.bbclass relies on KERNEL_DEVICETREE and it can't be modified without causing side effects at the kernel class and multi-dtb, an anonymous python snippet is added to the base qcom-distro image recipe, disabling it when using multi-dtb.

This is a temporary workaround and should be removed once the upstream proposal [1] gets accepted by upstream.

[1] https://lists.openembedded.org/g/openembedded-core/message/231436