### PR TITLE
Enable SPDX generation in QCOM distros

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -54,6 +54,7 @@ IMAGE_FSTYPES:remove = "tar.gz"
 INITRAMFS_IMAGE = "initramfs-rootfs-image"
 
 INHERIT += "buildhistory"
+INHERIT += "create-spdx"
 INHERIT += "image-buildinfo"
 INHERIT += "recipe_sanity"
 


### PR DESCRIPTION
SPDX metadata generation is required to support license compliance and SBOM
requirements for QLI builds. Inherit the `create-spdx` class as part of the base distro
configuration to ensure SPDX metadata is generated consistently across all QCOM distros.