### PR TITLE
qcom-base: update after core default changes

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -59,11 +59,5 @@ INHERIT += "recipe_sanity"
 
 BUILDHISTORY_COMMIT = "1"
 
-require conf/distro/include/security_flags.inc
-require conf/distro/include/yocto-space-optimize.inc
-require conf/distro/include/yocto-uninative.inc
-
-INHERIT += "uninative"
-
 # Disable weston idle timeout
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"


### PR DESCRIPTION
security_flags.inc, yocto-space-optimize.inc and yocto-uninative.inc are now part of defaultsetup.conf.