### PR TITLE
qcom-base: remove DISTRO_FEATURES which are already set by default

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -13,20 +13,15 @@ TARGET_VENDOR = "-qcom"
 DISTROOVERRIDES =. "${@ 'qcom-distro:' if d.getVar('DISTRO') != 'qcom-distro' else ''}"
 
 DISTRO_FEATURES:append = " \
-    bluetooth \
     efi \
     glvnd \
     opencl \
-    opengl \
     overlayfs \
     pam \
     pni-names \
-    ptest \
     security \
     tpm2 \
     virtualization \
-    vulkan \
-    wayland \
     wifi \
     x11 \
 "


### PR DESCRIPTION
Bluetooth, opengl, ptest, vulkan and wayland are now enabled by default in oe-core.