### PR TITLE
qcom-distro-sota: exclude ptest from backfilled distro features

### DIFF
--- a/conf/distro/include/qcom-distro-sota.inc
+++ b/conf/distro/include/qcom-distro-sota.inc
@@ -4,5 +4,8 @@ INITRAMFS_IMAGE = "initramfs-ostree-image"
 
 DISTRO_NAME:append = " (OTA-enabled)"
 
+# ptest is not generally useful with ostree-based images (ro /usr)
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "ptest"
+
 # Generate an OSTree repository tarball during image build
 BUILD_OSTREE_REPO_TARBALL = "1"


### PR DESCRIPTION
OSTree-based systems use a read-only /usr (and often additional read-only filesystem directories), which prevents most ptests from running successfully since many of them expect writable locations during execution. As a result, enabling the ptest distro feature provides little practical value for sota/ostree images while adding extra build time and image size.

Add "ptest" to DISTRO_FEATURES_BACKFILL_CONSIDERED so that the feature is not automatically enabled through Yocto's backfill mechanism.