### PR TITLE
gstreamer1.0-plugins-bad: enable WebRTC support

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_%.bbappend
@@ -1,0 +1,3 @@
+# WebRTC is not enabled by default in the recipe due to its dependencies
+# (srt, libsrtp, libnice) are provided by the meta-oe and meta-multimedia layers
+PACKAGECONFIG:append:qcom-distro = " sctp srt srtp webrtc"


### PR DESCRIPTION
Enable WebRTC functionality by adding the required components (sctp, srt, srtp, webrtc) to PACKAGECONFIG.
This brings real‑time audio/video and data‑channel capabilities to GStreamer pipelines, allowing seamless peer‑to‑peer media transport and modern browser interoperability.