### PR TITLE
wowlan: enable magic-packet WoWLAN

### DIFF
--- a/recipes-connectivity/wowlan/files/wowlan-enable.service
+++ b/recipes-connectivity/wowlan/files/wowlan-enable.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Enable WoWLAN magic packet on phy0
+After=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/sh -c 'until iw phy0 info; do sleep 1; done'
+ExecStart=/usr/sbin/iw phy0 wowlan enable magic-packet
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+

--- a/recipes-connectivity/wowlan/wowlan-enable_1.0.bb
+++ b/recipes-connectivity/wowlan/wowlan-enable_1.0.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Enable WoWLAN magic packet at boot"
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause-Clear;md5=7a434440b651f4a472ca93716d01033a"
+
+inherit systemd
+
+SRC_URI = "file://wowlan-enable.service"
+
+SYSTEMD_SERVICE:${PN} = "wowlan-enable.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/sources/wowlan-enable.service \
+        ${D}${systemd_system_unitdir}
+}
+

--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -14,6 +14,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-qcom-utilities-bluetooth-utils \
     packagegroup-qcom-utilities-filesystem-utils \
     resize-rootfs \
+    wowlan-enable \
 "
 
 # Default root password: oelinux123


### PR DESCRIPTION
On QCx6490 platforms, XO shutdown is blocked by WPSS votes on interconnect bandwidth and XO unless WoWLAN magic-packet trigger is enabled. Votes are released only after running:
  iw phy0 wowlan enable magic-packet

Add a systemd oneshot service that waits for phy0 to appear and enables magic-packet WoWLAN during boot. Although this change is motivated by a QCx6490-specific requirement, WoWLAN itself is a generic feature needed across platforms.