### PR TITLE
gstreamer1.0-plugins-good: enable GTK support

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,0 +1,3 @@
+# gtk is an optional feature from the recipe and not enabled by default
+# gtk plugins are needed for UI-based sample apps
+PACKAGECONFIG:append:qcom-distro = " gtk"


### PR DESCRIPTION
Enable GTK integration to provide GTK-based video sinks within GStreamer pipelines. 
This allows applications to render video directly inside GTK widgets for GStreamer-based multimedia applications.