### PR TITLE
qcom-multimedia-image: add gstreamer1.0-python

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -14,6 +14,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \
     gstreamer1.0-plugins-good \
+    gstreamer1.0-python \
     libcamera \
     libcamera-gst \
     libdrm-tests \


### PR DESCRIPTION
Include gstreamer1.0-python to enable Python bindings for GStreamer, allowing Python applications in the image to construct and control GStreamer pipelines using the Gst Python API.
This addition supports running GStreamer based Python applications.