### PR TITLE
qcom-base: enable SPDX_INCLUDE_KERNEL_CONFIG by default

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -45,6 +45,10 @@ PACKAGE_CLASSES = "package_rpm"
 # Avoid to duplicate the rootfs tarball by generating both tar.gz/tar.xz
 IMAGE_FSTYPES:remove = "tar.gz"
 
+# Extended SPDX / SBOM options
+## Include kernel config by default in SBOM
+SPDX_INCLUDE_KERNEL_CONFIG ?= "1"
+
 # Pull in the initrd image by default
 INITRAMFS_IMAGE = "initramfs-rootfs-image"
 


### PR DESCRIPTION
Enable SPDX_INCLUDE_KERNEL_CONFIG by default in order to include the kernel config used by the build as part of the image SBOM.

This is useful for debugging and also for validating the complete scope of the kernel used during the build process.