### PR TITLE
recipes-multimedia: enable bluetooth a2dp aptx codec

### DIFF
--- a/recipes-multimedia/libfreeaptx/libfreeaptx_0.2.2.bb
+++ b/recipes-multimedia/libfreeaptx/libfreeaptx_0.2.2.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Free aptX / aptX-HD audio codec library (LGPL fork of openaptx 0.2.0)"
+HOMEPAGE = "https://github.com/regularhunter/libfreeaptx"
+LICENSE = "LGPL-2.1-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c"
+
+PV = "0.2.2"
+
+SRC_URI = "git://github.com/regularhunter/libfreeaptx.git;protocol=https;branch=master"
+SRCREV  = "6dee419f934ec781e531f885f7e8e740752e67d1"
+
+inherit pkgconfig
+
+EXTRA_OEMAKE = "\
+  LIBDIR=${baselib} \
+  CFLAGS='${CFLAGS}' \
+  CPPFLAGS='${CPPFLAGS}' \
+  LDFLAGS='${LDFLAGS}' \
+  CP='cp -a --no-preserve=ownership' \
+"
+
+do_compile() {
+    oe_runmake
+}
+
+do_install() {
+    oe_runmake DESTDIR=${D} PREFIX=${prefix} install
+}
+
+PACKAGES =+ "${PN}-utils"
+
+FILES:${PN}        += "${libdir}/libfreeaptx.so.*"
+FILES:${PN}-dev    += "${includedir}/freeaptx.h ${libdir}/libfreeaptx.so ${libdir}/pkgconfig/libfreeaptx.pc"
+FILES:${PN}-utils  += "${bindir}/freeaptxenc ${bindir}/freeaptxdec"

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -4,3 +4,8 @@ SYSTEMD_AUTO_ENABLE:${PN}-pulse:qcom-distro = "enable"
 SYSTEMD_PACKAGES:append:qcom-distro = " ${PN}-pulse"
 
 FILES:${PN}-pulse:append:qcom-distro = " ${systemd_unitdir}/system-preset/98-pipewire-pulse.preset"
+
+# Enable aptx
+EXTRA_OEMESON:remove = " -Dbluez5-codec-aptx=disabled "
+PACKAGECONFIG[bluez-aptx]     = "-Dbluez5-codec-aptx=enabled,-Dbluez5-codec-aptx=disabled,libfreeaptx"
+PACKAGECONFIG:append:class-target = " bluez-aptx"

--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -32,6 +32,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     weston-examples \
     weston-init \
     wireplumber \
+    libfreeaptx \
 "
 
 # IMSDK currently only used and tested on ARMv8 (aarch64) machines.


### PR DESCRIPTION
Enable aptX/aptX-HD in PipeWire via PACKAGECONFIG

Remove the upstream Meson option that disables the BlueZ aptX codec and enable aptX support through PACKAGECONFIG.

Add libfreeaptx as the required dependency and include it in the multimedia image so aptX/aptX-HD can be built and used at runtime.

CRs-Fixed: 4459923,4459941