### PR TITLE
qcom-multimedia-image: add tensorflow-lite-tools to image install list

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -27,6 +27,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     pipewire-pulse \
     pipewire-spa-tools \
     pipewire-tools \
+    tensorflow-lite-tools \
     userspace-resource-manager \
     weston \
     weston-examples \


### PR DESCRIPTION
Included tensorflow-lite-tools as part of CORE_IMAGE_BASE_INSTALL to support TensorFlow Lite tooling in the multimedia image.