### PR TITLE
systemd: package lib/nvpcr as part of systemd

### DIFF
--- a/recipes-core/systemd/systemd_259.1.bbappend
+++ b/recipes-core/systemd/systemd_259.1.bbappend
@@ -1,0 +1,2 @@
+# Temporary workaround until https://lists.openembedded.org/g/openembedded-core/message/232523 is merged
+FILES:${PN}:append:qcom-distro = " ${exec_prefix}/lib/nvpcr"


### PR DESCRIPTION
systemd 259 includes NvPCRs JSON snippets when tpm2 support is enabled via packageconfig, so make sure they are also included as part of the main systemd package.

This is a temporary packaging fix, until the correct fix lands in oe-core.

Upstream patch for oe-core:
https://lists.openembedded.org/g/openembedded-core/message/232523