### PR TITLE
packagegroup-qcom-utilities: enable wowlan-udev

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -63,6 +63,7 @@ RDEPENDS:${PN}-network-utils = " \
     rsync \
     smbclient \
     tcpdump \
+    wowlan-udev \
     "
 
 RDEPENDS:${PN}-profile-utils = " \


### PR DESCRIPTION
On QCx6490 platforms, XO shutdown is blocked by WPSS votes on interconnect bandwidth and XO unless WoWLAN magic-packet trigger is enabled. Votes are released only after running:
  iw phy0 wowlan enable magic-packet

Enable wowlan-udev to install a udev rule that automatically enables WoWLAN magic-packet support when a Wi-Fi PHY is registered. Although this change is motivated by a QCx6490-specific requirement, WoWLAN is a generic feature and is useful across platforms.

wowlan-udev patch was accepted:
https://patchwork.yoctoproject.org/project/oe/patch/20260304053810.1001453-1-miaoqing.pan@oss.qualcomm.com/