### PR TITLE
qcom-multimedia-image: include gstd (GStreamer Daemon)

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -10,6 +10,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     alsa-utils-alsaucm \
     alsa-utils-aplay \
     ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'docker-compose', '', d)} \
+    gstd \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad \
     gstreamer1.0-plugins-base \


### PR DESCRIPTION
This change integrates the upstream GStreamer Daemon (gstd) into the qcom-multimedia-image to enable remote lifecycle management of GStreamer pipelines. By including gstd, the image gains the ability to create, modify, and monitor pipelines programmatically—supporting both TCP and HTTP (REST API) interfaces.

Upstream gstd listens on 127.0.0.1 by default, and the address can be changed using -a <ip> in the service file.