### PR TITLE
qcom-multimedia-image: add pulseaudio pactl client for audio control

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -29,6 +29,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     pipewire-pulse \
     pipewire-spa-tools \
     pipewire-tools \
+    pulseaudio-pactl \
     tensorflow-lite-tools \
     thermald \
     userspace-resource-manager \


### PR DESCRIPTION
Add the pulseaudio-pactl package to the multimedia image to
provide the pactl client tool for audio management on
PipeWire-based systems.