### PR TITLE
Revert "systemd: package lib/nvpcr as part of systemd"

### DIFF
--- a/recipes-core/systemd/systemd_259.1.bbappend
+++ b/recipes-core/systemd/systemd_259.1.bbappend
@@ -1,2 +1,0 @@
-# Temporary workaround until https://lists.openembedded.org/g/openembedded-core/message/232523 is merged
-FILES:${PN}:append:qcom-distro = " ${exec_prefix}/lib/nvpcr"


### PR DESCRIPTION
This reverts commit 59c066fcdcf607418af59630830d9964cbffd187.

Fix now available in oe-core [1].

[1]
https://git.openembedded.org/openembedded-core/commit/?id=1fc1fac23a4a2944943965746ba21f6d85c4e9b0