### PR TITLE
distro/qcom: enable virtfs in qemu PACKAGECONFIG

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -60,3 +60,5 @@ BUILDHISTORY_COMMIT = "1"
 
 # Disable weston idle timeout
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
+
+PACKAGECONFIG:append:pn-qemu = " virtfs"


### PR DESCRIPTION
QEMU-based development often requires sharing host directories with the guest to allow rapid iteration, debugging, and experimentation without rebuilding images. Enabling virtfs support allows using passthrough file sharing mechanisms, significantly reducing developer turnaround time. Tested by setting up a share between guest and host.