### PR TITLE
weston-init: Move Qdemo launcher entries to external weston.ini

### DIFF
--- a/recipes-multimedia/imsdk/files/weston-qdemo-launcher.ini
+++ b/recipes-multimedia/imsdk/files/weston-qdemo-launcher.ini
@@ -1,0 +1,4 @@
+
+[launcher]
+icon=/usr/share/qdemo/Qdemo.png
+path=/usr/bin/Qdemo

--- a/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bbappend
+++ b/recipes-multimedia/imsdk/gst-plugins-imsdk_0.1.0.bbappend
@@ -1,0 +1,20 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:qcom-distro = " file://weston-qdemo-launcher.ini"
+
+do_install:append:qcom-distro() {
+    install -d ${D}${datadir}/qdemo
+    install -m 0644 ${UNPACKDIR}/weston-qdemo-launcher.ini ${D}${datadir}/qdemo/
+}
+
+FILES:${PN}-apps:append:qcom-distro = " ${datadir}/qdemo/weston-qdemo-launcher.ini"
+
+pkg_postinst_ontarget:${PN}-apps:qcom-distro() {
+    cat /usr/share/qdemo/weston-qdemo-launcher.ini >> /etc/xdg/weston/weston.ini
+}
+
+pkg_postrm_ontarget:${PN}-apps:qcom-distro() {
+    if [ -f /etc/xdg/weston/weston.ini ]; then
+        sed -i '/^$/{N;N;N; /^\n\[launcher\]\nicon=\/usr\/share\/qdemo\/Qdemo.png\npath=\/usr\/bin\/Qdemo$/d}' /etc/xdg/weston/weston.ini
+    fi
+}


### PR DESCRIPTION
Move Qdemo launcher definitions into a separate weston.ini - qdemo-launcher-weston.ini file and append it during do_install for cleaner separation and easier maintenance. This will enable the Qdemo.png image to be displayed on the wayland display. Upon clicking this icon, gst-gui-launcher-app.py application will run.