### PR TITLE
ci: update to actions/checkout@v6

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -34,7 +34,9 @@ jobs:
           wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
           chmod +x ${KAS_CONTAINER}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run kas lock
         run: |
@@ -57,7 +59,9 @@ jobs:
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
@@ -114,7 +118,9 @@ jobs:
             yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run kas build
         uses: qualcomm-linux/meta-qcom/.github/actions/compile@master
@@ -209,7 +215,9 @@ jobs:
                 yamlfile: ""
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run kas build
         uses: qualcomm-linux/meta-qcom/.github/actions/compile@master

--- a/.github/workflows/qualcomm-linux-organization-repolinter.yml
+++ b/.github/workflows/qualcomm-linux-organization-repolinter.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Verify repolinter config file is present
         id: check_files
         uses: andstor/file-existence-action@v3

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Verify repolinter config file is present
         id: check_files
         uses: andstor/file-existence-action@v3


### PR DESCRIPTION
The following warning has been around for quite some time:

 Node.js 20 actions are deprecated. The following actions are running
 on Node.js 20 and may not work as expected:
 actions/checkout@v4. Actions will be forced to run with Node.js 24 by
 default starting June 2nd, 2026. Please check if updated versions of
 these actions are available that support Node.js 24

Github actions/checkout@v6 has been released for quite some time, it's time to upgrade here.