### PR TITLE
spice-gtk: enable libva-x11 and drop gstreamer1.0-vaapi

### DIFF
--- a/ci/yocto-check-layer.sh
+++ b/ci/yocto-check-layer.sh
@@ -41,6 +41,8 @@ echo 'REQUIRED_DISTRO_FEATURES = "xen"' >> meta-patch/recipes-patch/patch/exampl
 echo 'INSANE_SKIP:${PN}:remove = "installed-vs-shipped"' >> meta-patch/recipes-patch/patch/example-xen-guest-bundle_%.bbappend
 # alpine-xen-guest-bundle-3.23: Package alpine-xen-guest-bundle is skipping required QA tests. [installed-vs-shipped]
 echo 'INSANE_SKIP:${PN}:remove = "installed-vs-shipped"' >> meta-patch/recipes-patch/patch/alpine-xen-guest-bundle_%.bbappend
+# Missing or unbuildable dependency chain was: ['meta-world-pkgdata', 'virt-viewer', 'spice-gtk', 'gstreamer1.0-vaapi']
+echo 'DEPENDS:remove = "gstreamer1.0-vaapi"' >> meta-patch/recipes-patch/patch/spice-gtk_%.bbappend
 
 # DISTRO features of qcom-distro
 echo 'DISTRO_FEATURES:append:nodistro = " \

--- a/recipes-support/spice/spice-gtk_%.bbappend
+++ b/recipes-support/spice/spice-gtk_%.bbappend
@@ -1,0 +1,2 @@
+DEPENDS:remove:qcom-distro = "gstreamer1.0-vaapi"
+DEPENDS:append:qcom-distro = " libva"


### PR DESCRIPTION
OE-Core has dropped gstreamer1.0-vaaapi, breaking spice-gtk. Drop the dependency and, while we are at it, enable libva as a dependency, making sure VA-API is enabled.

Link: https://lore.kernel.org/r/20260316223525.1537696-1-dmitry.baryshkov@oss.qualcomm.com/