### PR TITLE
ci: publish_summary bring changes from meta-qcom

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -250,61 +250,10 @@ jobs:
 
   publish_summary:
     needs: compile
-    runs-on: [self-hosted, qcom-u2404, amd64]
+    if: always()
+    runs-on: ubuntu-latest
     steps:
-      - name: 'Download build URLs'
-        uses: actions/download-artifact@v7
+      - uses: qualcomm-linux/meta-qcom/.github/actions/print-build-output@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: build-url*
-          path: urlfiles
-          merge-multiple: true
-
-      - name: "Print output"
-        shell: python
-        id: print-output
-        run: |
-          import os
-          ftable = {}
-          oslist = set()
-          machinelist = set()
-          for fname in os.listdir("./urlfiles"):
-              if fname.startswith("build-url"):
-                  b, m, o = fname.split("_", 2)
-                  oslist.add(o)
-                  machinelist.add(m)
-                  url = ""
-                  with open(f"./urlfiles/{fname}", "r") as urlfile:
-                      url = urlfile.read()
-                  if not o in ftable:
-                      ftable.update({o:{m: url}})
-                  else:
-                      ftable[o].update({m: url})
-
-          table_str = "| |"
-
-          for m in sorted(machinelist):
-              table_str += f" {m} |"
-
-          table_str += "\n|"
-          for i in range(len(machinelist) + 1):
-              table_str += " ---- |"
-
-          table_str += "\n"
-
-          for o in sorted(ftable.keys()):
-              table_str += f"| {o} |"
-              for m in sorted(machinelist):
-                  url = ftable[o].get(m)
-                  if url:
-                      url = url.strip()
-                      table_str += f" [Files]({url}/{o}/{m}/) |"
-                  else:
-                      table_str += " |"
-              table_str += "\n"
-          summary_file_name = os.environ.get("GITHUB_STEP_SUMMARY")
-          if summary_file_name:
-              with open(summary_file_name, "a") as summaryfile:
-                  summaryfile.write("## Download URLs\n")
-                  summaryfile.write(table_str)
-          print(table_str)


### PR DESCRIPTION
Sync changes from meta-qcom:
1. move the bulk of the job in a common action
2. use a GitHub runner instead of self-hosted
3. always generate the table even if some build failed