### PR TITLE
Add minidebuginfo to DISTRO_FEATURES

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -15,6 +15,7 @@ DISTROOVERRIDES =. "${@ 'qcom-distro:' if d.getVar('DISTRO') != 'qcom-distro' el
 DISTRO_FEATURES:append = " \
     efi \
     glvnd \
+    minidebuginfo \
     opencl \
     overlayfs \
     pam \


### PR DESCRIPTION
Enable the `minidebuginfo` DISTRO_FEATURE to retrieve a symbolicated call-stack using GDB backtrace command without deploying full debug symbols to the target. This improves stack traces and profiling support without significantly increasing image size.