### PR TITLE
distro/qcom: make /var/tmp a persistent directory

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -63,3 +63,6 @@ BUILDHISTORY_COMMIT = "1"
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
 
 PACKAGECONFIG:append:pn-qemu = " virtfs"
+
+# Make /var/tmp a persistent real directory
+FILESYSTEM_PERMS_TABLES:remove = "files/fs-perms-volatile-tmp.txt"


### PR DESCRIPTION
This PR addresses the issue https://github.com/qualcomm-linux/meta-qcom/issues/1756

OE-Core defaults to /var/tmp being a symlink to /var/volatile/tmp, which is backed by a RAM-based tmpfs.  This violates FHS 3.0 §5.15, which requires /var/tmp to preserve files across reboots:
  https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s15.html

It also causes runtime failures: if the tmpfs is not yet mounted when early userspace runs, the symlink target does not exist and operations like mkdir -p /var/tmp/qtee_supplicant fail with ENOENT.

OE-Core provides a clean opt-out mechanism (introduced alongside VOLATILE_TMP_DIR removal): removing files/fs-perms-volatile-tmp.txt from FILESYSTEM_PERMS_TABLES makes base-files install /var/tmp as a real 1777 directory.  Systemd's 00-create-volatile.conf still has "L /var/tmp -> /var/volatile/tmp", but the L type without + is a no-op when the path already exists as a non-symlink, so no further override is needed.

This is a distro-level policy decision and belongs here rather than in the BSP layer (meta-qcom), where it would silently affect all users of the BSP regardless of their chosen distribution.