### PR TITLE
weston-init: append weston-terminal launcher entry

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " file://weston-terminal.ini"
+
+do_install:append:qcom-distro() {
+    cat ${WORKDIR}/sources/weston-terminal.ini >> ${D}${sysconfdir}/xdg/weston/weston.ini
+}

--- a/recipes-graphics/wayland/weston-init/weston-terminal.ini
+++ b/recipes-graphics/wayland/weston-init/weston-terminal.ini
@@ -1,0 +1,4 @@
+
+[launcher]
+icon=/usr/share/weston/terminal.png
+path=/usr/bin/weston-terminal


### PR DESCRIPTION
This change adds weston-terminal.ini to SRC_URI and updates do_install to append its contents to ${sysconfdir}/xdg/weston/weston.ini.