### PR TITLE
layer.conf: update to be compatible with wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -26,4 +26,4 @@ LAYERDEPENDS_qcom-distro = " \
 LAYERRECOMMENDS_qcom-distro = " \
     meta-audioreach \
 "
-LAYERSERIES_COMPAT_qcom-distro = "styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_qcom-distro = "wrynose"


### PR DESCRIPTION
OE-core has switched to using wrynose release name. Adjust LAYERSERIES_COMPAT accordingly. styhead and walnascar are not supported anymore so drop those as well.