### PR TITLE
pipewire: backport patches to build with glibc 2.43

### DIFF
--- a/recipes-multimedia/pipewire/files/0001-spa-plugins-alsa-acp-compat.h-Fix-missed-Wdiscarded-.patch
+++ b/recipes-multimedia/pipewire/files/0001-spa-plugins-alsa-acp-compat.h-Fix-missed-Wdiscarded-.patch
@@ -1,0 +1,28 @@
+From c847b8162959c29b783585e0dcadbfb096e7cb73 Mon Sep 17 00:00:00 2001
+From: Ripley Tom <discofan420@protonmail.com>
+Date: Sat, 21 Feb 2026 19:33:11 +0100
+Subject: [PATCH] spa/plugins/alsa/acp/compat.h: Fix missed
+ -Wdiscarded-qualifiers warning
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/c847b8162959c29b783585e0dcadbfb096e7cb73]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+---
+ spa/plugins/alsa/acp/compat.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/spa/plugins/alsa/acp/compat.h b/spa/plugins/alsa/acp/compat.h
+index f7592e1a6..0f7b959df 100644
+--- a/spa/plugins/alsa/acp/compat.h
++++ b/spa/plugins/alsa/acp/compat.h
+@@ -429,9 +429,9 @@ static PA_PRINTF_FUNC(1,0) inline char *pa_vsprintf_malloc(const char *fmt, va_l
+ 
+ #define pa_fopen_cloexec(f,m)	fopen(f,m"e")
+ 
+-static inline char *pa_path_get_filename(const char *p)
++static inline const char *pa_path_get_filename(const char *p)
+ {
+-    char *fn;
++    const char *fn;
+     if (!p)
+         return NULL;
+     if ((fn = strrchr(p, PA_PATH_SEP_CHAR)))

--- a/recipes-multimedia/pipewire/files/0002-spa-plugins-alsa-acp-compat.h-p-is-already-const-do-.patch
+++ b/recipes-multimedia/pipewire/files/0002-spa-plugins-alsa-acp-compat.h-p-is-already-const-do-.patch
@@ -1,0 +1,25 @@
+From 1a37f445a20e67976c83360ab5830887fffe37e2 Mon Sep 17 00:00:00 2001
+From: Rudi Heitbaum <rudi@heitbaum.com>
+Date: Tue, 17 Mar 2026 03:17:15 +1100
+Subject: [PATCH] spa/plugins/alsa/acp/compat.h: p is already const do not
+ recast
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/pipewire/pipewire/-/commit/1a37f445a20e67976c83360ab5830887fffe37e2]
+Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>
+---
+ spa/plugins/alsa/acp/compat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/spa/plugins/alsa/acp/compat.h b/spa/plugins/alsa/acp/compat.h
+index 0f7b959df..87151d197 100644
+--- a/spa/plugins/alsa/acp/compat.h
++++ b/spa/plugins/alsa/acp/compat.h
+@@ -436,7 +436,7 @@ static inline const char *pa_path_get_filename(const char *p)
+         return NULL;
+     if ((fn = strrchr(p, PA_PATH_SEP_CHAR)))
+         return fn+1;
+-    return (char*) p;
++    return p;
+ }
+ 
+ static inline bool pa_is_path_absolute(const char *fn)

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,3 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:qcom-distro = " \
+    file://0001-spa-plugins-alsa-acp-compat.h-Fix-missed-Wdiscarded-.patch \
+    file://0002-spa-plugins-alsa-acp-compat.h-p-is-already-const-do-.patch \
+"
+
 # Enable pipewire-pulse as a system-wide service
 SYSTEMD_SERVICE:${PN}-pulse:qcom-distro = "pipewire-pulse.service"
 SYSTEMD_AUTO_ENABLE:${PN}-pulse:qcom-distro = "enable"


### PR DESCRIPTION
Building pipewire with glibc 2.43 causes errors:

| ../sources/pipewire-1.6.2/spa/plugins/alsa/acp/compat.h:437:13: error: assignment discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
|   437 |     if ((fn = strrchr(p, PA_PATH_SEP_CHAR)))
|       |             ^

Backport upstream patches to fix.

This should be reverted once it's merged in meta-multimedia.

Link: https://lists.openembedded.org/g/openembedded-devel/message/125376