### PR TITLE
Disable `netcf` PACKAGECONFIG in libvirt recipe to fix build errors

### DIFF
--- a/recipes-extended/libvirt/libvirt_git.bbappend
+++ b/recipes-extended/libvirt/libvirt_git.bbappend
@@ -1,3 +1,7 @@
 # Temporarily disable warnings due deprecated libxml2 APIs until the proper fix
 # gets backported and merged in meta-virtualization
 CFLAGS:append:qcom-distro = " -Wno-deprecated-declarations"
+
+# netcf support fails to build with gnulib v202601.
+# Temporarily disable it in PACKAGECONFIG to allow libvirt compilation.
+PACKAGECONFIG:remove = "netcf"


### PR DESCRIPTION
The netcf recipe in meta-openembedded fails to build with gnulib v202601, causing libvirt compilation to break. Until the underlying issue is fixed upstream, disable netcf support in the libvirt PACKAGECONFIG.