### PR TITLE
packagegroup-qcom-test-pkgs: add sigma-dut

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -20,6 +20,7 @@ RDEPENDS:${PN} = "\
     openssh-sftp-server \
     pulseaudio-misc \
     rng-tools \
+    sigma-dut \
     util-linux \
     v4l-utils \
     yavta \


### PR DESCRIPTION
sigma-dut is a Wi-Fi Alliance certification testing tool that implements the Sigma Control API. It acts as a Device Under Test (DUT) that receives test commands from external certification test controllers via a TCP protocol, executes Wi-Fi operations on the device, and returns results.

Add sigma-dut to the qcom-utilities network utils packagegroup.