### PR TITLE
codeowners: copy CI reviewers from meta-qcom

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Default reviewers for all changes in entire repository,
 # unless a later match takes precedence
-*  @vkraleti @ricardosalveti @sbanerjee-quic @ndechesne @lumag
+*  @vkraleti @ricardosalveti @sbanerjee-quic @ndechesne @lumag @anujm1 @koenkooi
 
 # Reviewers to be assigned for any changes in ci/ subdirectory
 ci/*  @quaresmajose @ricardosalveti @sbanerjee-quic @ndechesne @mwasilew @lumag


### PR DESCRIPTION
Copy the reviewers for ci/ from meta-qcom and also use them for .github/*, which otherwise has no default reviewers.