### PR TITLE
qcom-multimedia-image: include thermald

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -29,6 +29,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     pipewire-spa-tools \
     pipewire-tools \
     tensorflow-lite-tools \
+    thermald \
     userspace-resource-manager \
     weston \
     weston-examples \


### PR DESCRIPTION
This change adds the upstream thermald daemon to the qcom-multimedia-image, enabling thermal monitoring and management on supported platforms.