### PR TITLE
pipewire: add dma_heap supplementary group

### DIFF
--- a/recipes-multimedia/pipewire/pipewire/dmaheap.conf
+++ b/recipes-multimedia/pipewire/pipewire/dmaheap.conf
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Allow PipeWire to access DMA-HEAP for system-wide daemon mode
+
+[Service]
+SupplementaryGroups=dmaheap

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,3 +1,13 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " file://dmaheap.conf"
+
+do_install:append:qcom-distro() {
+    install -d ${D}${systemd_system_unitdir}/pipewire.service.d
+    install -m 0644 ${UNPACKDIR}/dmaheap.conf \
+        ${D}${systemd_system_unitdir}/pipewire.service.d/dmaheap.conf
+}
+
 # Enable pipewire-pulse as a system-wide service
 SYSTEMD_SERVICE:${PN}-pulse:qcom-distro = "pipewire-pulse.service"
 SYSTEMD_AUTO_ENABLE:${PN}-pulse:qcom-distro = "enable"


### PR DESCRIPTION
On AudioReach-enabled qcom-distro systems, PipeWire fails to open /dev/dma_heap/system because it lacks the required permission context. This causes runtime failures in AudioReach flows that depend on dma-buf/dma_heap.

Resolve this by ensuring PipeWire runs with the required dma_heap access context, so it has the needed access and AudioReach pipelines can start reliably.