### PR TITLE
Revert changes to remove netcf from PACKAGECONFIG in libvirt recipe

### DIFF
--- a/recipes-extended/libvirt/libvirt_git.bbappend
+++ b/recipes-extended/libvirt/libvirt_git.bbappend
@@ -1,7 +1,3 @@
 # Temporarily disable warnings due deprecated libxml2 APIs until the proper fix
 # gets backported and merged in meta-virtualization
 CFLAGS:append:qcom-distro = " -Wno-deprecated-declarations"
-
-# netcf support fails to build with gnulib v202601.
-# Temporarily disable it in PACKAGECONFIG to allow libvirt compilation.
-PACKAGECONFIG:remove = "netcf"


### PR DESCRIPTION
These should be reverted as netcf has been fixed in meta-networking now.