### PR TITLE
qcom-multimedia-image: sort out ICD providers

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -8,11 +8,6 @@ BAD_RECOMMENDATIONS = " \
     libvulkan-adreno1 \
 "
 
-# Make sure that we have open-source Vulkan ICD installed
-CORE_IMAGE_BASE_INSTALL += " \
-    mesa-vulkan-drivers \
-"
-
 # Error out if any of the closed source packages get pulled into the image
 INCOMPATIBLE_LICENSE = "LICENSE.qcom LICENSE.qcom-2"
 


### PR DESCRIPTION
Fix preferences for ICD providers, letting us to drop manual installation of mesa-vulkan-drivers from the qcom-multimedia-image recipe.