### PR TITLE
qcom-multimedia-image: Extend license exceptions list with SDK packages

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -11,12 +11,19 @@ BAD_RECOMMENDATIONS = " \
 # Error out if any of the closed source packages get pulled into the image
 INCOMPATIBLE_LICENSE = "LICENSE.qcom LICENSE.qcom-2"
 
-# Allow closed source firmware packages
+# Allow closed source firmware and a few dependent packages
 INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     camxfirmware-kodiak:LICENSE.qcom-2 \
     camxfirmware-lemans:LICENSE.qcom-2 \
     camxfirmware-monaco:LICENSE.qcom-2 \
     camxfirmware-talos:LICENSE.qcom-2 \
+    camx-kodiak:LICENSE.qcom-2 \
+    camx-lemans:LICENSE.qcom-2 \
+    camxlib-kodiak:LICENSE.qcom-2 \
+    camxlib-lemans:LICENSE.qcom-2 \
+    chicdk-kodiak:LICENSE.qcom-2 \
+    chicdk-lemans:LICENSE.qcom-2 \
+    diag-router:LICENSE.qcom-2 \
     firmware-qcom-boot-glymur:LICENSE.qcom-2 \
     firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
@@ -25,6 +32,8 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-qcs9100:LICENSE.qcom-2 \
     firmware-qcom-boot-qrb2210-rb1:LICENSE.qcom \
     firmware-qcom-boot-sm8750:LICENSE.qcom-2 \
+    libdiag:LICENSE.qcom-2 \
+    qcom-sensors-binaries:LICENSE.qcom-2 \
     trusted-firmware-a-qcom:LICENSE.qcom \
 "
 


### PR DESCRIPTION
Some additional closed‑source packages built as part of qcom-multimedia-image 
are also pulled into the SDK. Since INCOMPATIBLE_LICENSE checks apply to SDK 
builds as well, these packages must be explicitly exempted to avoid license‑related
build failures during populate_sdk task.