### PR TITLE
qcom-multimedia-image: drop gst-plugins-imsdk-oss-meta from SDK

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -32,3 +32,6 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
 # be an error. Disable the check as we need to include boot firmware into the
 # image.
 ERROR_QA:remove = "license-exception"
+
+# Drop packages that cause incompatible license conflicts in the SDK
+TOOLCHAIN_TARGET_TASK:remove = "gst-plugins-imsdk-oss-meta"


### PR DESCRIPTION
The gst-plugins-imsdk-oss-meta package, when included in the SDK, pulls in proprietary dependencies that trigger incompatible license checks. This causes SDK generation failures even though the image itself builds successfully.

Remove gst-plugins-imsdk-oss-meta from TOOLCHAIN_TARGET_TASK to prevent it from being included in the SDK. This allows SDK generation to complete successfully while preserving the required image contents.