### PR TITLE
Revert "libvirt: temporarily set -W=no-deprecated-declarations"

### DIFF
--- a/recipes-extended/libvirt/libvirt_git.bbappend
+++ b/recipes-extended/libvirt/libvirt_git.bbappend
@@ -1,3 +1,0 @@
-# Temporarily disable warnings due deprecated libxml2 APIs until the proper fix
-# gets backported and merged in meta-virtualization
-CFLAGS:append:qcom-distro = " -Wno-deprecated-declarations"


### PR DESCRIPTION
Revert commit afd67fb and a follow-up fix 78d980c as the upstream fixes are now available in libvirt-12.1.0 in meta-virtualization.