### PR TITLE
qcom-base: enable pixman and VNC features for qemu

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -62,4 +62,4 @@ BUILDHISTORY_COMMIT = "1"
 # Disable weston idle timeout
 PACKAGECONFIG:append:pn-weston-init = " no-idle-timeout"
 
-PACKAGECONFIG:append:pn-qemu = " virtfs"
+PACKAGECONFIG:append:pn-qemu = " pixman virtfs vnc-jpeg vnc-sasl"


### PR DESCRIPTION
Graphical debugging and remote access use cases require pixman-based rendering and authenticated VNC support. Add pixman, vnc-jpeg, and vnc-sasl to qemu PACKAGECONFIG.

Fixes https://github.com/qualcomm-linux/meta-qcom/issues/1600