### PR TITLE
qcom-console-image: add modemmanager

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -16,4 +16,5 @@ CORE_IMAGE_BASE_INSTALL += " \
 
 CORE_IMAGE_EXTRA_INSTALL += " \
     libgomp \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'phone', 'modemmanager', '', d)} \
 "


### PR DESCRIPTION
Add modemmanager recipe to the console image when the 'phone' MACHINE_FEATURE is enabled to support basic telephony functionality, including SMS handling and data connectivity.