### PR TITLE
qcom-console-image: add git to the base image

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -10,6 +10,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     alsa-utils-alsaucm \
     alsa-utils-aplay \
     ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'docker-compose', '', d)} \
+    git \
     gstd \
     gstreamer1.0 \
     gstreamer1.0-plugins-bad \


### PR DESCRIPTION
Added git and essential Python3 tools (pip, setuptools, wheel, venv, ensurepip) to the base image to support python and tflite based workflow within the multimedia prop image.