### PR TITLE
ci: import ci.yml from meta-qcom

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+  - ci/mirror.yml
+
+local_conf_header:
+  ci: |
+    INHERIT:remove = "rm_work"


### PR DESCRIPTION
Compile action now expects ci.yml kas fragment to be available locally, import from meta-qcom 864bd0e344db.

meta-qcom pr: https://github.com/qualcomm-linux/meta-qcom/pull/1458