### PR TITLE
mesa: append gallivm patch.

### DIFF
--- a/recipes-graphics/mesa/mesa.bbappend
+++ b/recipes-graphics/mesa/mesa.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " file://gallivm-Fix-armhf-build-against-LLVM-22.patch"

--- a/recipes-graphics/mesa/mesa/gallivm-Fix-armhf-build-against-LLVM-22.patch
+++ b/recipes-graphics/mesa/mesa/gallivm-Fix-armhf-build-against-LLVM-22.patch
@@ -1,0 +1,28 @@
+From db9728708d8a06f60bb850788d4cde487ac671f4 Mon Sep 17 00:00:00 2001
+From: Alessandro Astone <ales.astone@gmail.com>
+Date: Sun, 1 Mar 2026 18:14:09 +0100
+Subject: [PATCH] gallivm: Fix armhf build against LLVM 22
+
+StringMapIterator<bool> became StringMapIterBase<bool, false /* IsConst */>;
+Use `auto` to handle either case.
+Upstream-Status: Inappropriate [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/40161]
+---
+ src/gallium/auxiliary/gallivm/lp_bld_misc.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
+index ce8ca02bf745..86779f013c7b 100644
+--- a/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
++++ b/src/gallium/auxiliary/gallivm/lp_bld_misc.cpp
+@@ -331,7 +331,7 @@ lp_build_fill_mattrs(std::vector<std::string> &MAttrs)
+       llvm::sys::getHostCPUFeatures(features);
+    #endif
+ 
+-   for (llvm::StringMapIterator<bool> f = features.begin();
++   for (auto f = features.begin();
+         f != features.end();
+         ++f) {
+       MAttrs.push_back(((*f).second ? "+" : "-") + (*f).first().str());
+-- 
+GitLab
+


### PR DESCRIPTION
To fix armhf build against LLVM 22.
StringMapIterator<bool> became StringMapIterBase<bool, false /* IsConst */>; Use `auto` to handle either case.