### PR TITLE
networkmanager: enable modemmanager support for 'phone' devices

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom-distro = " ${@bb.utils.contains('MACHINE_FEATURES', 'phone', ' modemmanager ', '', d)}"


### PR DESCRIPTION
Enable ModemManager in NetworkManager when the 'phone' MACHINE_FEATURE is enabled.