### PR TITLE
Add systemd config fragment to disable power key handling

### DIFF
--- a/recipes-core/systemd/systemd-conf/disable-powerkey.conf
+++ b/recipes-core/systemd/systemd-conf/disable-powerkey.conf
@@ -1,0 +1,2 @@
+[Login]
+HandlePowerKey=ignore

--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend:qcom-distro := "${THISDIR}/${BPN}:"
+
+SRC_URI:append:qcom-distro = " file://disable-powerkey.conf"
+
+do_install:append:qcom-distro() {
+   install -Dm 0644 ${UNPACKDIR}/disable-powerkey.conf \
+           ${D}${systemd_unitdir}/logind.conf.d/disable-powerkey.conf
+}


### PR DESCRIPTION
Add a systemd-logind configuration fragment to ignore
power key events. This prevents systemd-logind from 
triggering power-off actions when the power key is pressed.