### PR TITLE
Add benchmark packagegroup for platform performance testing

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -20,6 +20,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     libcamera-gst \
     libdrm-tests \
     ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', 'packagegroup-container', '', d)} \
+    packagegroup-qcom-benchmark \
     packagegroup-qcom-test-pkgs \
     packagegroup-qcom-utilities-gpu-utils \
     pipewire \

--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Qualcomm benchmark packagegroup"
+DESCRIPTION = "Package group to bring in benchmarking packages"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = "\
+    glmark2 \
+    "


### PR DESCRIPTION
Introduce packagegroup-qcom-benchmark to enable platform benchmarking capabilities. The packagegroup includes glmark2 configured with wayland-gles2 support and is integrated into qcom-multimedia-image.

This allows for graphics performance testing and provides a framework to add additional benchmark tools in the future.