### PR TITLE
recipes-products: Add qcom-networking-image

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -46,6 +46,10 @@ repos:
       .:
       meta-tpm:
 
+  meta-dpdk:
+    branch: master
+    url: https://git.yoctoproject.org/meta-dpdk
+
 local_conf_header:
   virtualization:
     SKIP_META_VIRT_SANITY_CHECK = "1"

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -58,3 +58,4 @@ target:
   - qcom-multimedia-image
   - qcom-multimedia-proprietary-image
   - qcom-container-orchestration-image
+  - qcom-networking-image

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -25,5 +25,10 @@ LAYERDEPENDS_qcom-distro = " \
 "
 LAYERRECOMMENDS_qcom-distro = " \
     meta-audioreach \
+    meta-dpdk \
+"
+BBFILES_DYNAMIC += " \
+    dpdk:${LAYERDIR}/dynamic-layers/dpdk/*/*/*.bb \
+    dpdk:${LAYERDIR}/dynamic-layers/dpdk/*/*/*.bbappend \
 "
 LAYERSERIES_COMPAT_qcom-distro = "wrynose"

--- a/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
+++ b/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
@@ -1,0 +1,1 @@
+CORE_IMAGE_BASE_INSTALL += "dpdk"

--- a/recipes-products/images/qcom-networking-image.bb
+++ b/recipes-products/images/qcom-networking-image.bb
@@ -1,0 +1,7 @@
+require qcom-console-image.bb
+
+SUMMARY = "Image with Networking features"
+
+CORE_IMAGE_BASE_INSTALL += " \
+    sigma-dut \
+"


### PR DESCRIPTION
Introduce new qcom-networking-image to add packages related to networking.
This change adds the DPDK package which is a framework for directly accessing the NIC cards queues for packet processing thereby bypassing the kernel network stack.