### PR TITLE
meta-qcom-distro:Enable QWES for proprietary image

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -19,6 +19,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     libdiag-bin \
     qcom-adreno \
     qcom-sensors-binaries \
+    qwes \
 "
 CORE_IMAGE_BASE_INSTALL:append = " \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', ' packagegroup-audioreach', '', d)} \


### PR DESCRIPTION
Enables the downstream QWES solution for proprietary images. This component is required to support platform feature management and device attestation services. Since QWES is a proprietary Qualcomm solution, it is enabled only for proprietary images.