### PR TITLE
Add coremark cpu benchmark

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -4,5 +4,6 @@ DESCRIPTION = "Package group to bring in benchmarking packages"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
+    coremark \
     glmark2 \
     "


### PR DESCRIPTION
packagegroup-qcom-benchmark : Add support to bring in CoreMark benchmark as part of the benchmark packagegroup to benchmark CPU performance and regressions.  