### PR TITLE
workflows/build-yocto: use qcom-distro name for qcom-armv7a workflow

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -208,7 +208,7 @@ jobs:
                 yamlfile: ""
           - machine: qcom-armv7a
             distro:
-                name: qcom-distro-multimedia-image
+                name: qcom-distro
                 yamlfile: ':ci/qcom-distro-multimedia-image.yml'
             kernel:
                 type: default


### PR DESCRIPTION
LAVA test plans expect the distro name to match a valid distro defined in meta-qcom-distro. Using `qcom-distro-multimedia-image` as the distro name causes test jobs to fail when attempting to fetch build artifacts.

Update the build-yocto workflow to use `qcom-distro` as the distro name for the qcom-armv7a machine, while continuing to use the qcom-distro-multimedia-image kas configuration to restrict builds to the multimedia image.