### PR TITLE
dpdk: disable examples and unused net PMDs

### DIFF
--- a/dynamic-layers/dpdk/recipes-extended/dpdk/dpdk_%.bbappend
+++ b/dynamic-layers/dpdk/recipes-extended/dpdk/dpdk_%.bbappend
@@ -1,0 +1,5 @@
+EXTRA_OEMESON:remove = "-Dexamples=all"
+EXTRA_OEMESON:append = " -Dexamples=   \
+		         -Ddisable_drivers='net/virtio,net/vmxnet3, \
+                         net/ena,net/octeontx,net/thunderx' \
+"


### PR DESCRIPTION
Disable building DPDK examples to reduce build time and image size. Also explicitly disable unused network PMDs (virtio, vmxnet3, ena, octeontx, thunderx) via Meson options, while keeping required drivers enabled.

This is done via a bbappend under the dynamic dpdk layer so the changes apply only when meta-dpdk is present.