### PR TITLE
qcom-distro: default SELinux to enforcing mode

### DIFF
--- a/conf/distro/include/qcom-distro-selinux.inc
+++ b/conf/distro/include/qcom-distro-selinux.inc
@@ -4,7 +4,7 @@ DISTRO_FEATURES_FILTER_NATIVESDK:append = " selinux"
 
 DISTRO_EXTRA_RDEPENDS:append = " packagegroup-core-selinux"
 
-DEFAULT_ENFORCING ?= "permissive"
+DEFAULT_ENFORCING ?= "enforcing"
 
 IMAGE_CLASSES += "selinux-image"
 


### PR DESCRIPTION
SELinux enforcing mode is the expected configuration for production builds. Switching the distro-level default improves the baseline security posture while keeping flexibility for products or development builds to override the setting if required.
