### PR TITLE
qcom-networking-image: drop dpdk from the image

### DIFF
--- a/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
+++ b/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
@@ -1,1 +1,0 @@
-CORE_IMAGE_BASE_INSTALL += "dpdk"


### PR DESCRIPTION
DPDK is not to a state where we can integrate as part of our CI yet due the huge amount of disk space required due static linking of the components, so drop for now until the optimizations are done upstream.