### PR TITLE
dpdk: enable PACKAGECONFIG to build shared libraries

### DIFF
--- a/dynamic-layers/dpdk/recipes-extended/dpdk/dpdk_%.bbappend
+++ b/dynamic-layers/dpdk/recipes-extended/dpdk/dpdk_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom-distro = " shared"


### PR DESCRIPTION
By default, DPDK performs static linking for applications and examples [1]. This behaviour can cause the build directory to exceed 100 GiB.

Enable PACKAGECONFIG to allow building with shared libraries only.

[1] dpdk commit 93b1f90ae174 ("build: change default library type to static")