### PR TITLE
qcom-multimedia-image: add exception for firmware-qcom-boot-qrb2210

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -24,6 +24,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs9100:LICENSE.qcom-2 \
+    firmware-qcom-boot-qrb2210:LICENSE.qcom-2 \
     firmware-qcom-boot-qrb2210-rb1:LICENSE.qcom \
     firmware-qcom-boot-sm8750:LICENSE.qcom-2 \
     trusted-firmware-a-qcom:LICENSE.qcom \


### PR DESCRIPTION
Add firmware-qcom-boot-qrb2210 to the license exception list in order to allow the integration of the new edk2-based boot firmware release.

The old rb1-based boot firmware release is not removed in order to support transitioning to the new firmware without breaking compatibility with the older one.