### PR TITLE
ci/qcom-distro: set defaults branch

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -5,6 +5,10 @@ header:
 
 distro: qcom-distro
 
+defaults:
+  repos:
+    branch: master
+
 repos:
   meta-qcom-distro:
 
@@ -21,29 +25,23 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
-    branch: master
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach
-    branch: master
 
   meta-selinux:
-    branch: master
     url: https://git.yoctoproject.org/meta-selinux
 
   meta-updater:
-    branch: master
     url: https://github.com/uptane/meta-updater
 
   meta-security:
     url: https://git.yoctoproject.org/meta-security
-    branch: master
     layers:
       .:
       meta-tpm:
 
   meta-dpdk:
-    branch: master
     url: https://git.yoctoproject.org/meta-dpdk
 
 local_conf_header:


### PR DESCRIPTION
We can simplify and define a default branch for all layers and specify only the branch for divergent cases.

Based on [1] form meta-qcom.

[1]
https://github.com/qualcomm-linux/meta-qcom/commit/49bfe9bf16cab28cb7e4476305afaa7e6857bfb9