### PR TITLE
Revert "qcom-networking-image: drop dpdk from the image"

### DIFF
--- a/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
+++ b/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
@@ -1,0 +1,1 @@
+CORE_IMAGE_BASE_INSTALL += "dpdk"


### PR DESCRIPTION
Reverts qualcomm-linux/meta-qcom-distro#279

With upstream DPDK now supporting a package config for building shared libraries, the disk space requirement has come down significantly when this config is enabled. Reverting the PR so that ci can be enabled.