### PR TITLE
ci: switch layers to wrynose

### DIFF
--- a/ci/base.yml
+++ b/ci/base.yml
@@ -9,6 +9,6 @@ header:
 repos:
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    branch: master
+    branch: wrynose
 
   meta-qcom-distro:

--- a/ci/meta-qcom.yml
+++ b/ci/meta-qcom.yml
@@ -6,4 +6,4 @@ header:
 repos:
   meta-qcom:
     url: https://github.com/qualcomm-linux/meta-qcom
-    branch: master
+    branch: wrynose

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -7,7 +7,7 @@ distro: qcom-distro
 
 defaults:
   repos:
-    branch: master
+    branch: wrynose
 
 repos:
   meta-qcom-distro:
@@ -25,9 +25,11 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
+    branch: master
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach
+    branch: master
 
   meta-selinux:
     url: https://git.yoctoproject.org/meta-selinux
@@ -37,12 +39,14 @@ repos:
 
   meta-security:
     url: https://git.yoctoproject.org/meta-security
+    branch: master
     layers:
       .:
       meta-tpm:
 
   meta-dpdk:
     url: https://git.yoctoproject.org/meta-dpdk
+    branch: master
 
 local_conf_header:
   virtualization:


### PR DESCRIPTION
Switch all layers which do have a wrynose branch to track wrynose, as this branch is now tracking the wrynose release.