### PR TITLE
ci: add workflow for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,22 @@
+name: Backport merged pull request
+on:
+  pull_request_target:
+    types: [closed]
+permissions:
+  contents: write # so it can comment
+  pull-requests: write # so it can create pull requests
+jobs:
+  backport:
+    name: Backport pull request
+    runs-on: ubuntu-latest
+    # Don't run on closed unmerged pull requests
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Create backport pull requests
+        uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # 4.5.0
+        with:
+          label_pattern: "^backport (wrynose)$"
+          branch_name: "backport/${pull_number}-to-${target_branch}"


### PR DESCRIPTION
Add workflow to enable support to automatically backport pull-requests as they are merged, based on the tags used at the time of the merge.

Workflow uses https://github.com/korthout/backport-action, at a fixed revision based on the 4.5.0 release.

Same as https://github.com/qualcomm-linux/meta-qcom/pull/2076.