### PR TITLE
[backport wrynose] qcom-distro: default SELinux to enforcing

### DIFF
--- a/conf/distro/include/qcom-distro-selinux.inc
+++ b/conf/distro/include/qcom-distro-selinux.inc
@@ -4,7 +4,7 @@ DISTRO_FEATURES_FILTER_NATIVESDK:append = " selinux"
 
 DISTRO_EXTRA_RDEPENDS:append = " packagegroup-core-selinux"
 
-DEFAULT_ENFORCING ?= "permissive"
+DEFAULT_ENFORCING ?= "enforcing"
 
 IMAGE_CLASSES += "selinux-image"
 


### PR DESCRIPTION
Switch the default SELinux mode from permissive to enforcing at the distro level.

This aligns with production security expectations while still allowing products to override the default if required.


(cherry picked from commit 6b9272458a8ebc028b287c1282f49d788c39c3ff)