### PR TITLE
packagegroup-qcom-benchmark: Add dhrystone synthetic benchmark

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -5,5 +5,6 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     coremark \
+    dhrystone \
     glmark2 \
     "


### PR DESCRIPTION
Add dhrystone to packagegroup-qcom-benchmark. Dhrystone is a synthetic benchmark that evaluates integer performance and efficiency of CPU.