### PR TITLE
packagegroup-qcom-benchmark: Add network benchmarks

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -7,4 +7,6 @@ RDEPENDS:${PN} = "\
     coremark \
     dhrystone \
     glmark2 \
+    iperf3 \
+    netperf \
     "


### PR DESCRIPTION
Add iperf and netperf to benchmark network performance