### PR TITLE
ci: workflows/backport: switch to PAT token

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,5 +18,6 @@ jobs:
       - name: Create backport pull requests
         uses: korthout/backport-action@7c3f6cd5843cac11bc59a04a1b7699af93261670 # 4.5.0
         with:
+          github_token: ${{ secrets.QUIC_YOCTO_BACKPORT_PAT }}
           label_pattern: "^backport (wrynose)$"
           branch_name: "backport/${pull_number}-to-${target_branch}"


### PR DESCRIPTION
Backport PRs created by the workflow using GITHUB_TOKEN do not trigger additional workflow runs due to github actions recursion protection.

Switch the backport-action authentication to a repo-scoped PAT so that newly created backport pull requests fire the usual pull_request CI workflows.

This follows backport-action guidance to use an explicit token via the github_token input (GITHUB_TOKEN or PAT), while keeping the workflow trigger on pull_request_target for required write access.

Based on [1] form meta-qcom.

[1]
https://github.com/qualcomm-linux/meta-qcom/commit/6352cb67b1e74d69476bb7f82258a0cdda3c012f