### PR TITLE
packagegroup-qcom-benchmark: Add multiple SOC benchmarking apps

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -11,5 +11,6 @@ RDEPENDS:${PN} = "\
     iperf2 \
     lmbench \
     netperf \
+    phoronix-test-suite \
     sysbench \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -6,7 +6,10 @@ inherit packagegroup
 RDEPENDS:${PN} = "\
     coremark \
     dhrystone \
+    fio \
     glmark2 \
     iperf2 \
+    lmbench \
     netperf \
+    sysbench \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -10,6 +10,8 @@ RDEPENDS:${PN} = "\
     glmark2 \
     iperf2 \
     lmbench \
+    mbw \
+    memtester \
     netperf \
     phoronix-test-suite \
     sysbench \

--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -7,4 +7,6 @@ RDEPENDS:${PN} = "\
     coremark \
     dhrystone \
     glmark2 \
+    iperf2 \
+    netperf \
     "


### PR DESCRIPTION
Add memory, CPU, IO and networking benchmarking tools to package-group. 