### PR TITLE
qcom-multimedia-image:Add camxfirmware-hamoa in  INCOMPATIBLE_LICENSE_EXCEPTIONS

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -13,6 +13,7 @@ INCOMPATIBLE_LICENSE = "LICENSE.qcom LICENSE.qcom-2"
 
 # Allow closed source firmware packages
 INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
+    camxfirmware-hamoa:LICENSE.qcom-2 \
     camxfirmware-kodiak:LICENSE.qcom-2 \
     camxfirmware-lemans:LICENSE.qcom-2 \
     camxfirmware-monaco:LICENSE.qcom-2 \


### PR DESCRIPTION
Add camxfirmware-hamoa to INCOMPATIBLE_LICENSE_EXCEPTIONS to ensure that closed source firmware packages can be included in qcom-multimedia-image.