### PR TITLE
workflow/build-yocto: skip summary on forks and fail build_successful when compile fails

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -278,9 +278,14 @@ jobs:
           pattern: build-url*
 
   build_successful:
-    if: github.repository_owner == 'qualcomm-linux'
+    if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
     needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully
-        run: echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"
+        run: |
+          if [ "${{ needs.compile.result }}" != "success" ]; then
+            echo "compile result was ${{ needs.compile.result }}"
+            exit 1
+          fi
+          echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -269,7 +269,7 @@ jobs:
 
   publish_summary:
     needs: compile
-    if: always()
+    if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
     runs-on: ubuntu-latest
     steps:
       - uses: qualcomm-linux/meta-qcom/.github/actions/print-build-output@master
@@ -278,6 +278,7 @@ jobs:
           pattern: build-url*
 
   build_successful:
+    if: github.repository_owner == 'qualcomm-linux'
     needs: compile
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Gate publish_summary and build_successful jobs to run only in the qualcomm-linux repository and always run build_successful but make it depend on the compile step output, so we can reliably depend on it as a required check.