### PR TITLE
ci: sync pybootchartgui changes from meta-qcom

### DIFF
--- a/ci/yocto-buildstats.sh
+++ b/ci/yocto-buildstats.sh
@@ -43,3 +43,17 @@ CMD="$CMD $BUILDSTATS"
 
 echo $CMD
 eval $CMD
+
+# buildstats-summary tool
+CMD="buildstats-summary"
+# sort by task duration
+CMD="$CMD --sort duration"
+# disable highlight
+CMD="$CMD --highlight 0"
+# buildstats log folder
+CMD="$CMD $BUILDSTATS"
+# show and save it to
+CMD="$CMD | tee buildstats.log"
+
+echo $CMD
+eval $CMD

--- a/ci/yocto-buildstats.sh
+++ b/ci/yocto-buildstats.sh
@@ -37,8 +37,9 @@ CMD="$CMD --full-time"
 # image format (png, svg, pdf); default format png
 CMD="$CMD --format=svg"
 # output path (file or directory) where charts are stored
-CMD="$CMD --output=buildchart"
+CMD="$CMD --output=buildstats"
 # buildstats log folder
 CMD="$CMD $BUILDSTATS"
 
-exec $CMD
+echo $CMD
+eval $CMD

--- a/ci/yocto-pybootchartgui.sh
+++ b/ci/yocto-pybootchartgui.sh
@@ -21,15 +21,21 @@ _is_dir(){
 _is_dir "$REPO_DIR"
 _is_dir "$WORK_DIR"
 
+# latest buildstats folder
+BUILDSTATS="$WORK_DIR/build/tmp/buildstats"
+BUILDSTATS="$BUILDSTATS/$(ls $BUILDSTATS | tail -1)"
+
 # pybootchartgui tool
 CMD="$CMD $WORK_DIR/oe-core/scripts/pybootchartgui/pybootchartgui.py"
 # display time in minutes instead of seconds
 CMD="$CMD --minutes"
+# display the full time regardless of which processes are currently shown
+CMD="$CMD --full-time"
 # image format (png, svg, pdf); default format png
 CMD="$CMD --format=svg"
 # output path (file or directory) where charts are stored
 CMD="$CMD --output=buildchart"
 # /path/to/tmp/buildstats/<recipe-machine>/<BUILDNAME>/
-CMD="$CMD $WORK_DIR/build/tmp/buildstats"
+CMD="$CMD $BUILDSTATS"
 
 exec $CMD

--- a/ci/yocto-pybootchartgui.sh
+++ b/ci/yocto-pybootchartgui.sh
@@ -22,11 +22,14 @@ _is_dir "$REPO_DIR"
 _is_dir "$WORK_DIR"
 
 # latest buildstats folder
-BUILDSTATS="$WORK_DIR/build/tmp/buildstats"
+BUILDSTATS="$(bitbake-getvar --value TMPDIR)/buildstats"
 BUILDSTATS="$BUILDSTATS/$(ls $BUILDSTATS | tail -1)"
 
+# add pybootchartgui path
+PATH="$PATH:$WORK_DIR/oe-core/scripts/pybootchartgui"
+
 # pybootchartgui tool
-CMD="$CMD $WORK_DIR/oe-core/scripts/pybootchartgui/pybootchartgui.py"
+CMD="pybootchartgui.py"
 # display time in minutes instead of seconds
 CMD="$CMD --minutes"
 # display the full time regardless of which processes are currently shown
@@ -35,7 +38,7 @@ CMD="$CMD --full-time"
 CMD="$CMD --format=svg"
 # output path (file or directory) where charts are stored
 CMD="$CMD --output=buildchart"
-# /path/to/tmp/buildstats/<recipe-machine>/<BUILDNAME>/
+# buildstats log folder
 CMD="$CMD $BUILDSTATS"
 
 exec $CMD


### PR DESCRIPTION
Sync pybootchartgui changes from meta-qcom https://github.com/qualcomm-linux/meta-qcom/pull/2064.

Changes for compile action is not required as it is reused from meta-qcom@master.