### PR TITLE
packagegroup-qcom-utilities: Add paho-mqtt-c to network-utils

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -60,6 +60,7 @@ RDEPENDS:${PN}-network-utils = " \
     networkmanager \
     openssh-scp \
     openssh-ssh \
+    paho-mqtt-c \
     rsync \
     smbclient \
     tcpdump \


### PR DESCRIPTION
Add `paho-mqtt-c` MQTT client library to `packagegroup-qcom-utilities-network-utils`
for IoT/M2M messaging support on Qualcomm Linux.

**Testing:**
- Built `qcom-multimedia-proprietary-image` for `rb3gen2-core-kit` using kas
- Verified `paho-mqtt-c 1.3.16` present in image manifest
- Tested MQTT pub/sub using custom app with Mosquitto broker on RB3 Gen2 target

Signed-off-by: Harish Kumar <hakumar@qti.qualcomm.com>