### PR TITLE
Add Gunyah-specific distro configuration

### DIFF
--- a/ci/qcom-distro-gunyah.yml
+++ b/ci/qcom-distro-gunyah.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+   - ci/qcom-distro.yml
+
+distro: qcom-distro-gunyah

--- a/conf/distro/include/qcom-distro-gunyah.inc
+++ b/conf/distro/include/qcom-distro-gunyah.inc
@@ -1,0 +1,8 @@
+DISTRO_FEATURES:append = " \
+    gunyah \
+"
+
+DISTRO_NAME:append = " (Gunyah-enabled)"
+
+# Gunyah and KVM are mutually exclusive
+CONFLICT_DISTRO_FEATURES = "kvm"

--- a/conf/distro/include/qcom-distro-kvm.inc
+++ b/conf/distro/include/qcom-distro-kvm.inc
@@ -3,3 +3,6 @@ DISTRO_FEATURES:append = " \
 "
 
 DISTRO_NAME:append = " (KVM-enabled)"
+
+# Gunyah and KVM are mutually exclusive
+CONFLICT_DISTRO_FEATURES = "gunyah"

--- a/conf/distro/qcom-distro-gunyah.conf
+++ b/conf/distro/qcom-distro-gunyah.conf
@@ -1,0 +1,2 @@
+require conf/distro/include/qcom-base.inc
+require conf/distro/include/qcom-distro-gunyah.inc


### PR DESCRIPTION
Define qcom-distro-gunyah modeled after the KVM variant. It enables the 'gunyah' DISTRO_FEATURE and provides a dedicated configuration for Gunyah-based builds. 
