### PR TITLE
qcom-multimedia-proprietary-image: add protoc to SDK host tools for camera-service

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -25,3 +25,5 @@ CORE_IMAGE_BASE_INSTALL += " \
 CORE_IMAGE_BASE_INSTALL:append = " \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', ' packagegroup-audioreach', '', d)} \
 "
+
+TOOLCHAIN_HOST_TASK:append = " nativesdk-protobuf-camx-compiler"


### PR DESCRIPTION
camera-service requires the protoc compiler as a host-side build tool when compiling outside the Yocto environment using the standard SDK.

Add `nativesdk-protobuf-compiler` to TOOLCHAIN_HOST_TASK in qcom-multimedia-proprietary-image.bb to ensure protoc is available in the SDK.