### PR TITLE
qcom-distro: default SELinux to permissive mode

### DIFF
--- a/conf/distro/include/qcom-distro-selinux.inc
+++ b/conf/distro/include/qcom-distro-selinux.inc
@@ -4,7 +4,7 @@ DISTRO_FEATURES_FILTER_NATIVESDK:append = " selinux"
 
 DISTRO_EXTRA_RDEPENDS:append = " packagegroup-core-selinux"
 
-DEFAULT_ENFORCING ?= "enforcing"
+DEFAULT_ENFORCING ?= "permissive"
 
 IMAGE_CLASSES += "selinux-image"
 


### PR DESCRIPTION
Switch the default SELinux mode from enforcing to permissive at the distro level.
Some L4 test cases are failing in enforcing mode, and the GA release code freeze is near, making it difficult to upstream fixes before the code freeze.
To avoid blocking the release, defaulting to permissive mode.