### PR TITLE
Make KVM as a default distro feature

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -161,9 +161,9 @@ jobs:
           - type: 6.18
             dirname: "_linux-qcom-6.18"
             yamlfile: ":ci/linux-qcom-6.18.yml"
-          - type: rt-6.18-distro-kvm
-            dirname: "_linux-qcom-rt-6.18_qcom-distro-kvm"
-            yamlfile: ":ci/linux-qcom-rt-6.18.yml:ci/qcom-distro-kvm.yml"
+          - type: rt-6.18
+            dirname: "_linux-qcom-rt-6.18"
+            yamlfile: ":ci/linux-qcom-rt-6.18.yml"
         exclude:
           # Exclude jobs from compile_warm_up
           - machine: glymur-crd
@@ -199,22 +199,6 @@ jobs:
                 type: qcom-next-rt
                 dirname: "_linux-qcom-next-rt"
                 yamlfile: ":ci/linux-qcom-next-rt.yml"
-          - machine: iq-9075-evk
-            distro:
-                name: qcom-distro-kvm
-                yamlfile: ':ci/qcom-distro-kvm.yml'
-            kernel:
-                type: default
-                dirname: ""
-                yamlfile: ""
-          - machine: iq-8275-evk
-            distro:
-                name: qcom-distro-kvm
-                yamlfile: ':ci/qcom-distro-kvm.yml'
-            kernel:
-                type: default
-                dirname: ""
-                yamlfile: ""
           - machine: qcom-armv7a
             distro:
                 name: qcom-distro
@@ -241,8 +225,8 @@ jobs:
                 yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit-open-fw
             distro:
-                name: qcom-distro-kvm
-                yamlfile: ':ci/qcom-distro-kvm.yml'
+                name: qcom-distro
+                yamlfile: ':ci/qcom-distro.yml'
             kernel:
                 type: default
                 dirname: ""

--- a/ci/qcom-distro-kvm.yml
+++ b/ci/qcom-distro-kvm.yml
@@ -1,8 +1,0 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
-
-header:
-  version: 14
-  includes:
-   - ci/qcom-distro.yml
-
-distro: qcom-distro-kvm

--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -15,6 +15,7 @@ DISTROOVERRIDES =. "${@ 'qcom-distro:' if d.getVar('DISTRO') != 'qcom-distro' el
 DISTRO_FEATURES:append = " \
     efi \
     glvnd \
+    kvm \
     minidebuginfo \
     opencl \
     overlayfs \

--- a/conf/distro/include/qcom-distro-kvm.inc
+++ b/conf/distro/include/qcom-distro-kvm.inc
@@ -1,5 +1,0 @@
-DISTRO_FEATURES:append = " \
-    kvm \
-"
-
-DISTRO_NAME:append = " (KVM-enabled)"

--- a/conf/distro/qcom-distro-kvm.conf
+++ b/conf/distro/qcom-distro-kvm.conf
@@ -1,2 +1,0 @@
-require conf/distro/include/qcom-base.inc
-require conf/distro/include/qcom-distro-kvm.inc


### PR DESCRIPTION
Qualcomm Linux aims to use KVM by default on supported platforms. Enabling the 'kvm' by default in DISTRO_FEATURES and dropping the dedicated qcom-distro-kvm.conf simplifies the distro configs.