### PR TITLE
Disable adbd autostart to reduce boot time

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -2,7 +2,7 @@ SUMMARY = "Minimal image"
 
 LICENSE = "BSD-3-Clause-Clear"
 
-IMAGE_FEATURES += "splash tools-debug allow-root-login post-install-logging enable-adbd"
+IMAGE_FEATURES += "splash tools-debug allow-root-login post-install-logging"
 
 inherit core-image features_check extrausers image-adbd
 


### PR DESCRIPTION
The Android Debug Bridge daemon (adbd) is primarily used for manual debugging tasks such as file transfer and does not need to run on every boot. Disable autostart to improve boot performance. 