### PR TITLE
[Backport wrynose] refpolicy: Backport changes required for Weston, Audio, coredump, qtee_supplicant failures

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -30,5 +30,7 @@ LAYERRECOMMENDS_qcom-distro = " \
 BBFILES_DYNAMIC += " \
     dpdk:${LAYERDIR}/dynamic-layers/dpdk/*/*/*.bb \
     dpdk:${LAYERDIR}/dynamic-layers/dpdk/*/*/*.bbappend \
+    selinux:${LAYERDIR}/dynamic-layers/selinux/*/*/*.bb \
+    selinux:${LAYERDIR}/dynamic-layers/selinux/*/*/*.bbappend \
 "
 LAYERSERIES_COMPAT_qcom-distro = "wrynose"

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-selinux-allow-ModemManager-to-send-DBus-messages-to-.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0001-selinux-allow-ModemManager-to-send-DBus-messages-to-.patch
@@ -1,0 +1,39 @@
+From 5684dae89f8d69717a17664193d3686fdf57fb6b Mon Sep 17 00:00:00 2001
+From: Jaihind Yadav <jaihindy@qti.qualcomm.com>
+Date: Tue, 12 May 2026 11:53:01 +0530
+Subject: [PATCH] selinux: allow ModemManager to send DBus messages to
+ initrc_t.
+
+SELinux denies D-Bus method_return messages from modemmanager_t to
+initrc_t and breaks the expected reply path on the bus.
+
+Addressed denial to allow method_return from modemmanager_t to 
+initrc_t.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1115]
+
+Signed-off-by: Jaihind Yadav <jaihindy@qti.qualcomm.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/system/init.te | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/policy/modules/system/init.te b/policy/modules/system/init.te
+index cb9c3d97a..b584997b5 100644
+--- a/policy/modules/system/init.te
++++ b/policy/modules/system/init.te
+@@ -1326,6 +1326,11 @@ optional_policy(`
+ 		networkmanager_dbus_chat(initrc_t)
+ 	')
+ 
++	optional_policy(`
++		# Needed by wireplumber to interact with ModemManager over D-Bus
++		modemmanager_dbus_chat(initrc_t)
++	')
++
+ 	optional_policy(`
+ 		policykit_dbus_chat(initrc_t)
+ 	')
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0002-selinux-allow-seatd-to-use-unallocated-TTYs.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0002-selinux-allow-seatd-to-use-unallocated-TTYs.patch
@@ -1,0 +1,33 @@
+From ebafd639e8d3847d0c8c2313c71994c4ea5e1501 Mon Sep 17 00:00:00 2001
+From: Jaihind Yadav <jaihindy@qti.qualcomm.com>
+Date: Tue, 12 May 2026 11:23:17 +0530
+Subject: [PATCH] selinux: allow seatd to use unallocated TTYs
+
+seatd requires access to unallocated TTY devices such as /dev/tty0
+to manage seat activation and VT handling for Wayland compositors.
+
+Added policies to allow seatd to access unallocated TTY devices.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1114]
+
+Signed-off-by: Jaihind Yadav <jaihindy@qti.qualcomm.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/services/seatd.te | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/policy/modules/services/seatd.te b/policy/modules/services/seatd.te
+index 44ba85ee7..d539dc446 100644
+--- a/policy/modules/services/seatd.te
++++ b/policy/modules/services/seatd.te
+@@ -32,3 +32,7 @@ auth_use_nsswitch(seatd_t)
+ 
+ dev_rw_dri(seatd_t)
+ dev_rw_input_dev(seatd_t)
++
++# seatd requires access to unallocated TTYs (e.g. /dev/tty0) to manage
++# seat activation and VT handling for Wayland compositors.
++term_use_unallocated_ttys(seatd_t)
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-refpolicy-Allow-alsa-to-write-on-event-dev-node.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0003-refpolicy-Allow-alsa-to-write-on-event-dev-node.patch
@@ -1,0 +1,36 @@
+From e0fd56a58954dc234b1a4d5ca30d4e80f84edd31 Mon Sep 17 00:00:00 2001
+From: Gargi Misra <gmisra@qti.qualcomm.com>
+Date: Mon, 18 May 2026 22:29:42 +0530
+Subject: [PATCH] refpolicy: Allow alsa to write on event dev node
+
+Observed below denial when alsa tried to write on event dev node.
+
+avc:  denied  { write } for  pid=792 comm="alsactl" name="controlC0"
+dev="devtmpfs" ino=1613 scontext=system_u:system_r:alsa_t:s0
+tcontext=system_u:object_r:event_device_t:s0 tclass=chr_file permissive=0
+
+Addressed denial to allow alsa to write on event dev node.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1117]
+
+Signed-off-by: Gargi Misra <gmisra@qti.qualcomm.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/admin/alsa.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/admin/alsa.te b/policy/modules/admin/alsa.te
+index 37d04a9e5..fd967cb82 100644
+--- a/policy/modules/admin/alsa.te
++++ b/policy/modules/admin/alsa.te
+@@ -87,6 +87,7 @@ dev_read_sound(alsa_t)
+ dev_read_sysfs(alsa_t)
+ dev_read_urand(alsa_t)
+ dev_write_sound(alsa_t)
++dev_rw_input_dev(alsa_t)
+ 
+ files_read_usr_files(alsa_t)
+ files_search_var_lib(alsa_t)
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0004-systemd-coredump-Allow-systemd-coredump-to-read.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0004-systemd-coredump-Allow-systemd-coredump-to-read.patch
@@ -1,0 +1,42 @@
+From 75079752d1fb3cd8a394a4c470ec9b1144cec1bd Mon Sep 17 00:00:00 2001
+From: Gargi Misra <gmisra@qti.qualcomm.com>
+Date: Mon, 18 May 2026 22:32:49 +0530
+Subject: [PATCH] systemd-coredump: Allow systemd-coredump to read
+namespace file
+
+SELinux is denying systemd-coredump from opening and reading
+a namespace file (nsfs_t).This blocks coredump collection paths that
+inspect process namespace descriptors, and can result in incomplete
+or failed crash dump handling for affected processes.
+
+Denial:
+type=AVC msg=audit(1776766842.302:2875): avc:  denied  { read open }
+for  pid=6273 comm="systemd-coredum" path="pid:[4026531836]" dev="nsfs"
+ino=4026531836 scontext=system_u:system_r:systemd_coredump_t:s0
+tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=0
+
+Allow systemd-coredump to open, read namespace file.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1117]
+
+Signed-off-by: Gargi Misra <gmisra@qti.qualcomm.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/system/systemd.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/system/systemd.te b/policy/modules/system/systemd.te
+index 63b105663..737f10a9b 100644
+--- a/policy/modules/system/systemd.te
++++ b/policy/modules/system/systemd.te
+@@ -563,6 +563,7 @@ fs_getattr_all_fs(systemd_coredump_t)
+ fs_getattr_nsfs_files(systemd_coredump_t)
+ fs_list_cgroup_dirs(systemd_coredump_t)
+ fs_search_tmpfs(systemd_coredump_t)
++fs_read_nsfs_files(systemd_coredump_t)
+ 
+ init_list_var_lib_dirs(systemd_coredump_t)
+ init_read_state(systemd_coredump_t)
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0005-libvirt_leasesh-Added-read-and-search-permission-on-.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0005-libvirt_leasesh-Added-read-and-search-permission-on-.patch
@@ -1,0 +1,49 @@
+From a7d4c1333edee3ea6b532979ae6d940360489793 Mon Sep 17 00:00:00 2001
+From: Gargi Misra <gmisra@qti.qualcomm.com>
+Date: Mon, 18 May 2026 22:53:07 +0530
+Subject: [PATCH] libvirt_leasesh: Added read and search permission on kernel
+ sysctls
+
+Observed below read and search denials on libvirt_leasesh accessing
+kernel sysctls.
+
+avc:  denied  { search } for  pid=1393 comm="libvirt_leasesh" name="kernel"
+dev="proc" ino=3693 scontext=system_u:system_r:virt_leaseshelper_t:s0
+tcontext=system_u:object_r:sysctl_kernel_t:s0 tclass=dir permissive=0
+avc:  denied  { read } for  pid=1363 comm="libvirt_leasesh" name="cap_last_cap"
+dev="proc" ino=13638 scontext=system_u:system_r:virt_leaseshelper_t:s0
+tcontext=system_u:object_r:sysctl_kernel_t:s0 tclass=file permissive=0
+avc:  denied  { open } for  pid=1359 comm="libvirt_leasesh" 
+path="/proc/sys/kernel/cap_last_cap" dev="proc" ino=2909
+scontext=system_u:system_r:virt_leaseshelper_t:s0
+tcontext=system_u:object_r:sysctl_kernel_t:s0 tclass=file permissive=0
+avc:  denied  { getattr } for  pid=1375 comm="libvirt_leasesh" name="/"
+dev="proc" ino=1 scontext=system_u:system_r:virt_leaseshelper_t:s0
+tcontext=system_u:object_r:proc_t:s0 tclass=filesystem permissive=0
+
+Addressed policies to allow libvirt_leasesh to read and search on kernel
+sysctls.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1117]
+
+Signed-off-by: Gargi Misra <gmisra@qti.qualcomm.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/services/virt.te | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/services/virt.te b/policy/modules/services/virt.te
+index 2241a22b5..0f6dc341e 100644
+--- a/policy/modules/services/virt.te
++++ b/policy/modules/services/virt.te
+@@ -1161,6 +1161,7 @@ manage_files_pattern(virt_leaseshelper_t, virt_runtime_t, virt_runtime_t)
+ files_runtime_filetrans(virt_leaseshelper_t, virt_runtime_t, file)
+ 
+ kernel_dontaudit_read_system_state(virt_leaseshelper_t)
++kernel_read_kernel_sysctls(virt_leaseshelper_t)
+ 
+ # Read /sys/devices/system/node/node*/meminfo
+ dev_list_sysfs(virt_leaseshelper_t)
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0006-Add-op-tee-based-tee-supplicant-policy.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0006-Add-op-tee-based-tee-supplicant-policy.patch
@@ -1,0 +1,83 @@
+From 0e76a2a30d459e9c8416225dc51280927d0f27b1 Mon Sep 17 00:00:00 2001
+From: Daniel Burgener <Daniel.Burgener@microsoft.com>
+Date: Wed, 8 Apr 2026 20:43:43 +0000
+Subject: [PATCH] Add op-tee based tee supplicant policy
+
+Some of the op-tee required policies are missing.
+
+Added required policies for op-tee.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1103]
+
+Signed-off-by: Daniel Burgener <Daniel.Burgener@microsoft.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/kernel/devices.if          | 18 ++++++++++++++++++
+ policy/modules/services/tee_supplicant.fc |  1 +
+ policy/modules/services/tee_supplicant.te | 12 +++++++++++-
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/policy/modules/kernel/devices.if b/policy/modules/kernel/devices.if
+index a7ebcc922..1e4ec76e5 100644
+--- a/policy/modules/kernel/devices.if
++++ b/policy/modules/kernel/devices.if
+@@ -5050,6 +5050,24 @@ interface(`dev_rw_tee',`
+ 	rw_chr_files_pattern($1, device_t, tee_device_t)
+ ')
+ 
++########################################
++## <summary>
++##	Read and write the privileged trusted execution environment devices.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`dev_rw_tee_priv',`
++	gen_require(`
++		type device_t, tee_priv_device_t;
++	')
++
++	rw_chr_files_pattern($1, device_t, tee_priv_device_t)
++')
++
+ ########################################
+ ## <summary>
+ ##	Read and write the TPM device.
+diff --git a/policy/modules/services/tee_supplicant.fc b/policy/modules/services/tee_supplicant.fc
+index 9c6e77836..41b654268 100644
+--- a/policy/modules/services/tee_supplicant.fc
++++ b/policy/modules/services/tee_supplicant.fc
+@@ -1 +1,2 @@
+ /usr/bin/qtee_supplicant      --      gen_context(system_u:object_r:tee_supplicant_exec_t,s0)
++/usr/sbin/tee-supplicant      --      gen_context(system_u:object_r:tee_supplicant_exec_t,s0)
+diff --git a/policy/modules/services/tee_supplicant.te b/policy/modules/services/tee_supplicant.te
+index 2d5905318..0e0b67bc2 100644
+--- a/policy/modules/services/tee_supplicant.te
++++ b/policy/modules/services/tee_supplicant.te
+@@ -9,9 +9,19 @@ type tee_supplicant_t;
+ type tee_supplicant_exec_t;
+ init_daemon_domain(tee_supplicant_t, tee_supplicant_exec_t)
+ 
+-########################################
++type tee_supplicant_var_lib_t;
++files_type(tee_supplicant_var_lib_t)
++
++#########################################
+ #
+ # Local policy
+ #
+ 
++manage_files_pattern(tee_supplicant_t, tee_supplicant_var_lib_t, tee_supplicant_var_lib_t)
++manage_dirs_pattern(tee_supplicant_t, tee_supplicant_var_lib_t, tee_supplicant_var_lib_t)
++files_var_lib_filetrans(tee_supplicant_t, tee_supplicant_var_lib_t, { file dir })
++
+ dev_rw_tee(tee_supplicant_t)
++dev_rw_tee_priv(tee_supplicant_t)
++
++kernel_read_vm_overcommit_sysctl(tee_supplicant_t)
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0007-tee_supplicant-Add-necessary-SELinux-policy-for-qtee.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0007-tee_supplicant-Add-necessary-SELinux-policy-for-qtee.patch
@@ -1,0 +1,237 @@
+From 694c913f851a332c6673b19cdfbeb3852a588d27 Mon Sep 17 00:00:00 2001
+From: Wenjia Zhang <wenjz@qti.qualcomm.com>
+Date: Thu, 16 Apr 2026 11:38:59 +0800
+Subject: [PATCH] tee_supplicant: Add necessary SELinux policy for
+ qtee_supplicant
+
+This change is adding some interfaces for qtee_supplicant which requires
+more permissions than OPTEE’s tee‑supplicant.
+
+Overall, some necessary permissions for qtee_supplicant to access
+system resources have been added.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1105]
+
+Signed-off-by: Wenjia Zhang <wenjia.zhang@oss.qualcomm.com>
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/kernel/storage.if          | 60 +++++++++++++++++++++++
+ policy/modules/services/tee_supplicant.fc |  2 +
+ policy/modules/services/tee_supplicant.if | 22 ++++++++-
+ policy/modules/services/tee_supplicant.te | 39 +++++++++++++++
+ policy/modules/system/init.te             |  4 ++
+ testing/sechecker.ini                     |  1 +
+ 6 files changed, 127 insertions(+), 1 deletion(-)
+
+diff --git a/policy/modules/kernel/storage.if b/policy/modules/kernel/storage.if
+index 81a4d1a61..19f0b2ab1 100644
+--- a/policy/modules/kernel/storage.if
++++ b/policy/modules/kernel/storage.if
+@@ -547,6 +547,36 @@ interface(`storage_read_scsi_generic',`
+ 	typeattribute $1 scsi_generic_read;
+ ')
+ 
++########################################
++## <summary>
++##      Allow the caller to directly read, in a
++##      generic fashion, from any SCSI device
++##      if a tunable is set.
++## </summary>
++## <param name="domain">
++##      <summary>
++##      Domain allowed access.
++##      </summary>
++## </param>
++## <param name="tunable">
++##      <summary>
++##      Tunable to depend on
++##      </summary>
++## </param>
++#
++interface(`storage_read_scsi_generic_cond',`
++        gen_require(`
++                attribute scsi_generic_read;
++                type scsi_generic_device_t;
++        ')
++
++        typeattribute $1 scsi_generic_read;
++        tunable_policy(`$2',`
++                dev_list_all_dev_nodes($1)
++                allow $1 scsi_generic_device_t:chr_file read_chr_file_perms;
++        ')
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the caller to directly write, in a
+@@ -572,6 +602,36 @@ interface(`storage_write_scsi_generic',`
+ 	typeattribute $1 scsi_generic_write;
+ ')
+ 
++########################################
++## <summary>
++##      Allow the caller to directly write, in a
++##      generic fashion, from any SCSI device
++##      if a tunable is set.
++## </summary>
++## <param name="domain">
++##      <summary>
++##      Domain allowed access.
++##      </summary>
++## </param>
++## <param name="tunable">
++##      <summary>
++##      Tunable to depend on
++##      </summary>
++## </param>
++#
++interface(`storage_write_scsi_generic_cond',`
++        gen_require(`
++                attribute scsi_generic_write;
++                type scsi_generic_device_t;
++        ')
++
++        typeattribute $1 scsi_generic_write;
++        tunable_policy(`$2',`
++                dev_list_all_dev_nodes($1)
++                allow $1 scsi_generic_device_t:chr_file write_chr_file_perms;
++        ')
++')
++
+ ########################################
+ ## <summary>
+ ##	Allow the caller to delete the generic
+diff --git a/policy/modules/services/tee_supplicant.fc b/policy/modules/services/tee_supplicant.fc
+index 41b654268..73c5022c4 100644
+--- a/policy/modules/services/tee_supplicant.fc
++++ b/policy/modules/services/tee_supplicant.fc
+@@ -1,2 +1,4 @@
+ /usr/bin/qtee_supplicant      --      gen_context(system_u:object_r:tee_supplicant_exec_t,s0)
+ /usr/sbin/tee-supplicant      --      gen_context(system_u:object_r:tee_supplicant_exec_t,s0)
++
++/var/lib/tee(/.*)?                    gen_context(system_u:object_r:tee_supplicant_var_lib_t,s0)
+diff --git a/policy/modules/services/tee_supplicant.if b/policy/modules/services/tee_supplicant.if
+index e22a531f5..5274d1e2c 100644
+--- a/policy/modules/services/tee_supplicant.if
++++ b/policy/modules/services/tee_supplicant.if
+@@ -1,5 +1,5 @@
+ ## <summary>tee_supplicant</summary>
+-#
++##
+ ## <desc>
+ ## qtee_supplicant is a userspace supplicant daemon that
+ ## services callback requests from QTEE via the Linux TEE subsystem.
+@@ -8,3 +8,23 @@
+ ##
+ ## https://github.com/qualcomm/minkipc/tree/main/qtee_supplicant
+ ## </desc>
++
++#####################
++## <summary>
++##  Allow the specified domain to create
++##  objects in /var/lib with an automatic
++##  transition to the tee_supplicant var lib type.
++## </summary>
++## <param name="domain">
++##  <summary>
++##  Domain allowed access.
++##  </summary>
++## </param>
++#
++interface(`tee_supplicant_var_lib_filetrans',`
++       gen_require(`
++               type tee_supplicant_var_lib_t;
++       ')
++
++       files_var_lib_filetrans($1, tee_supplicant_var_lib_t, dir, "qtee_supplicant")
++')
+diff --git a/policy/modules/services/tee_supplicant.te b/policy/modules/services/tee_supplicant.te
+index 0e0b67bc2..ab0cc2e8c 100644
+--- a/policy/modules/services/tee_supplicant.te
++++ b/policy/modules/services/tee_supplicant.te
+@@ -5,12 +5,20 @@ policy_module(tee_supplicant)
+ # Declarations
+ #
+ 
++## <desc>
++##  <p>
++##  Enable rules specific to qtee_supplicant.
++##  </p>
++## </desc>
++gen_tunable(tee_supplicant_qtee, false)
++
+ type tee_supplicant_t;
+ type tee_supplicant_exec_t;
+ init_daemon_domain(tee_supplicant_t, tee_supplicant_exec_t)
+ 
+ type tee_supplicant_var_lib_t;
+ files_type(tee_supplicant_var_lib_t)
++files_mountpoint(tee_supplicant_var_lib_t)
+ 
+ #########################################
+ #
+@@ -25,3 +33,34 @@ dev_rw_tee(tee_supplicant_t)
+ dev_rw_tee_priv(tee_supplicant_t)
+ 
+ kernel_read_vm_overcommit_sysctl(tee_supplicant_t)
++
++# Access qtee_supplicant to access UFS BSG device
++storage_read_scsi_generic_cond(tee_supplicant_t,tee_supplicant_qtee)
++storage_write_scsi_generic_cond(tee_supplicant_t,tee_supplicant_qtee)
++
++tunable_policy(`tee_supplicant_qtee',`
++
++        # Access qtee_supplicant to request sys_rawio capability
++        allow tee_supplicant_t self:capability sys_rawio;
++
++        # Allow qtee_supplicant to block system suspend by wake_lock
++        allow tee_supplicant_t self:capability2 block_suspend;
++
++        # Access qtee_supplicant to open/read /sys/firmware/devicetree/base/compatible
++        dev_read_sysfs(tee_supplicant_t)
++
++        # Access qtee_supplicant to write /sys/power/wake_lock
++        dev_write_sysfs(tee_supplicant_t)
++
++        # Access tee_supplicant to read /var
++        files_list_var(tee_supplicant_t)
++
++        # Access qtee_supplicant to visit /var/lib
++        files_list_var_lib(tee_supplicant_t)
++
++        # Access qtee_supplicant to access /proc/cmdline
++        kernel_read_system_state(tee_supplicant_t)
++
++        # Access qtee_supplicant to send logs to systemd journal
++        logging_send_syslog_msg(tee_supplicant_t)
++')
+diff --git a/policy/modules/system/init.te b/policy/modules/system/init.te
+index cb9c3d97a..141095ac8 100644
+--- a/policy/modules/system/init.te
++++ b/policy/modules/system/init.te
+@@ -1523,6 +1523,10 @@ optional_policy(`
+ 	sysnet_read_dhcpc_state(initrc_t)
+ ')
+ 
++optional_policy(`
++	tee_supplicant_var_lib_filetrans(initrc_t)
++')
++
+ optional_policy(`
+ 	udev_manage_runtime_files(initrc_t)
+ 	udev_manage_runtime_dirs(initrc_t)
+diff --git a/testing/sechecker.ini b/testing/sechecker.ini
+index 865a3cf8b..ab62696f2 100644
+--- a/testing/sechecker.ini
++++ b/testing/sechecker.ini
+@@ -221,6 +221,7 @@ exempt_source = abrt_t              # Conditional access (allow_raw_memory_acces
+                 sosreport_t         # Conditional access (allow_raw_memory_access)
+                 spc_t
+                 sysadm_t            # System admin role
++                tee_supplicant_t    # Access qtee_supplicant to request sys_rawio capability
+                 udev_t
+                 vbetool_t           # Conditional access (allow_raw_memory_access)
+                 vmware_t
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0008-dmesg-allow-dmesg_t-access-to-init-script-stream-soc.patch
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted/0008-dmesg-allow-dmesg_t-access-to-init-script-stream-soc.patch
@@ -1,0 +1,55 @@
+From 8a5020228bdae40fdf57d5d5987a1f3f4910a540 Mon Sep 17 00:00:00 2001
+From: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+Date: Thu, 28 May 2026 10:20:36 +0530
+Subject: [PATCH] dmesg: allow dmesg_t access to init script stream sockets
+
+dmesg was generating AVC denials when interacting with an init-script-owned
+UNIX stream socket for operations such as read, write, ioctl, and getattr on
+performing `adb shell dmesg`.
+
+Denials:
+type=AVC msg=audit(1773565011.851:411): avc: denied { ioctl } for pid=4782
+comm="dmesg" path="socket:[764973]" dev="sockfs" ino=764973 ioctlcmd=0x542a
+scontext=system_u:system_r:dmesg_t:s0 tcontext=system_u:system_r:initrc_t:s0
+tclass=unix_stream_socket permissive=1
+
+type=AVC msg=audit(1773565011.851:412): avc: denied { getattr } for pid=4782
+comm="dmesg" path="socket:[764973]" dev="sockfs" ino=764973
+scontext=system_u:system_r:dmesg_t:s0 tcontext=system_u:system_r:initrc_t:s0
+tclass=unix_stream_socket permissive=1
+
+type=AVC msg=audit(1773565011.851:410): avc: denied { read write } for pid=4782
+comm="dmesg" path="socket:[764973]" dev="sockfs" ino=764973
+scontext=system_u:system_r:dmesg_t:s0 tcontext=system_u:system_r:initrc_t:s0
+tclass=unix_stream_socket permissive=1
+
+type=AVC msg=audit(1773565011.851:411): avc: denied { ioctl } for pid=4782
+comm="dmesg" path="socket:[764973]" dev="sockfs" ino=764973 ioctlcmd=0x542a
+scontext=system_u:system_r:dmesg_t:s0 tcontext=system_u:system_r:initrc_t:s0
+tclass=unix_stream_socket permissive=1
+
+Grant the expected socket access for dmesg_t resolving the AVC denials.
+
+Upstream-Status: Submitted [https://github.com/SELinuxProject/refpolicy/pull/1137]
+
+Signed-off-by: Sasi Kumar Maddineni <sasikuma@qti.qualcomm.com>
+---
+ policy/modules/admin/dmesg.te | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/policy/modules/admin/dmesg.te b/policy/modules/admin/dmesg.te
+index 89478c38e..0d14dd227 100644
+--- a/policy/modules/admin/dmesg.te
++++ b/policy/modules/admin/dmesg.te
+@@ -54,6 +54,8 @@ userdom_use_user_terminals(dmesg_t)
+ 
+ mls_file_read_to_clearance(dmesg_t)
+ 
++init_rw_script_stream_sockets(dmesg_t)
++
+ optional_policy(`
+ 	seutil_sigchld_newrole(dmesg_t)
+ ')
+-- 
+2.43.0
+

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom-distro = " \
     file://0001-selinux-allow-ModemManager-to-send-DBus-messages-to-.patch \
+    file://0002-selinux-allow-seatd-to-use-unallocated-TTYs.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -6,4 +6,5 @@ SRC_URI:append:qcom-distro = " \
     file://0003-refpolicy-Allow-alsa-to-write-on-event-dev-node.patch \
     file://0004-systemd-coredump-Allow-systemd-coredump-to-read.patch \
     file://0005-libvirt_leasesh-Added-read-and-search-permission-on-.patch \
+    file://0006-Add-op-tee-based-tee-supplicant-policy.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " \
+    file://0001-selinux-allow-ModemManager-to-send-DBus-messages-to-.patch \
+"

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -5,4 +5,5 @@ SRC_URI:append:qcom-distro = " \
     file://0002-selinux-allow-seatd-to-use-unallocated-TTYs.patch \
     file://0003-refpolicy-Allow-alsa-to-write-on-event-dev-node.patch \
     file://0004-systemd-coredump-Allow-systemd-coredump-to-read.patch \
+    file://0005-libvirt_leasesh-Added-read-and-search-permission-on-.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -3,4 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append:qcom-distro = " \
     file://0001-selinux-allow-ModemManager-to-send-DBus-messages-to-.patch \
     file://0002-selinux-allow-seatd-to-use-unallocated-TTYs.patch \
+    file://0003-refpolicy-Allow-alsa-to-write-on-event-dev-node.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -8,4 +8,5 @@ SRC_URI:append:qcom-distro = " \
     file://0005-libvirt_leasesh-Added-read-and-search-permission-on-.patch \
     file://0006-Add-op-tee-based-tee-supplicant-policy.patch \
     file://0007-tee_supplicant-Add-necessary-SELinux-policy-for-qtee.patch \
+    file://0008-dmesg-allow-dmesg_t-access-to-init-script-stream-soc.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -7,4 +7,5 @@ SRC_URI:append:qcom-distro = " \
     file://0004-systemd-coredump-Allow-systemd-coredump-to-read.patch \
     file://0005-libvirt_leasesh-Added-read-and-search-permission-on-.patch \
     file://0006-Add-op-tee-based-tee-supplicant-policy.patch \
+    file://0007-tee_supplicant-Add-necessary-SELinux-policy-for-qtee.patch \
 "

--- a/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/dynamic-layers/selinux/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -4,4 +4,5 @@ SRC_URI:append:qcom-distro = " \
     file://0001-selinux-allow-ModemManager-to-send-DBus-messages-to-.patch \
     file://0002-selinux-allow-seatd-to-use-unallocated-TTYs.patch \
     file://0003-refpolicy-Allow-alsa-to-write-on-event-dev-node.patch \
+    file://0004-systemd-coredump-Allow-systemd-coredump-to-read.patch \
 "


### PR DESCRIPTION
With SELinux enforcing, several core platform components hit AVC denials that cause functional issues or service instability, including:
• ModemManager D-Bus reply path to init. (Causing failue of some Audio test cases )
• seatd access to unallocated TTYs(Causing Weston service failure due to which multimedia testing blocked)
• ALSA/event device node access
• systemd-coredump reads on namespace files (nsfs_t) (coredump collection failure)
• libvirt_leasesh access to kernel sysctls
• OP-TEE and qtee_supplicant policy gaps (qtee_supplicant service failure)
• dmesg_t access to init script stream sockets ("adb shell dmesg" command failure)