### PR TITLE
qcom-base: enable polkit by default

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -21,6 +21,7 @@ DISTRO_FEATURES:append = " \
     overlayfs \
     pam \
     pni-names \
+    polkit \
     security \
     tpm2 \
     virtualization \


### PR DESCRIPTION
Add polkit to the default DISTRO_FEATURES. polkit is the standard authorization framework that lets system D-Bus services grant fine-grained, per-action privileges to unprivileged and session clients, replacing coarse root-only checks with auditable, policy-driven authorization.

This is a sensible baseline for a general-purpose distribution: many components already shipped here integrate with polkit when the feature is enabled (e.g. NetworkManager, ModemManager, upower), gaining proper authorization policies instead of all-or-nothing access. It complements the distro's existing security profile and fits the current setup, which already enables systemd (used for logind session tracking) and pam (used as the polkit authentication backend). The polkit daemon is D-Bus activated, so enabling it adds no boot-time cost.