### PR TITLE
qcom-minimal-image: enable zram

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -14,6 +14,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     packagegroup-qcom-utilities-bluetooth-utils \
     packagegroup-qcom-utilities-filesystem-utils \
     resize-rootfs \
+    zram \
 "
 
 # Default root password: oelinux123


### PR DESCRIPTION
Add zram to the minimal image so that compressed swap is available across all images.