### PR TITLE
recipes-support: Enable nice elements

### DIFF
--- a/recipes-support/libnice/libnice_0.1%.bbappend
+++ b/recipes-support/libnice/libnice_0.1%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom-distro = " gstreamer"


### PR DESCRIPTION
Add bbappend to libnice to enable nicesrc and nicesink gst plugins