### PR TITLE
[Backport wrynose] qcom-base: enable polkit by default

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -21,6 +21,7 @@ DISTRO_FEATURES:append = " \
     overlayfs \
     pam \
     pni-names \
+    polkit \
     security \
     tpm2 \
     virtualization \


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom-distro/pull/325