### PR TITLE
recipes-connectivity: openssl: enable legacy provider by default

### DIFF
--- a/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom-distro = " legacy"


### PR DESCRIPTION
OpenSSL 3.x moved legacy algorithms into an opt-in loadable module (legacy.so), disabled by default via 'no-legacy'. While these algorithms are considered cryptographically weak in general, they remain required by widely deployed EAP authentication methods used in WPA2/WPA3 enterprise Wi-Fi certification.

Specifically, the following WPA3 certification test cases fail without the legacy provider enabled:

  - SCV 11.1.1  PEAP0
  - SCV 11.1.3  TTLS
  - SCV 11.1.4  PEAP1
  - SCV 11.1.6  PEAP1 UOSC

These EAP methods (PEAP, TTLS) rely on inner authentication protocols such as MSCHAPv2 which depend on MD4 — an algorithm provided exclusively by the legacy provider in OpenSSL 3.x.

Enable the 'legacy' PACKAGECONFIG so that legacy.so is built and packaged into openssl-ossl-module-legacy. The existing RRECOMMENDS:libcrypto on openssl-ossl-module-legacy ensures it is automatically pulled into all images without requiring explicit IMAGE_INSTALL entries.

Note that the legacy provider is not enabled by default at runtime.
Systems requiring these algorithms need to explicitly activate it via
OpenSSL configuration. For example:
  [openssl_init]
  providers = provider_sect

  [provider_sect]
  default = default_sect
  legacy = legacy_sect

  [default_sect]
  activate = 1

  [legacy_sect]
  activate = 1

Verification can be done with:
  openssl list -providers
  You should see both default and legacy loaded.

There are some background about why can't upstream it.
1. Security — the legacy provider contains old, cryptographically weak algorithms (MD4, MD2, RC2, RC4, DES, Blowfish, IDEA, etc.) that are considered broken or deprecated by modern standards. Enabling them by default would expose every OpenSSL-linked application to these weak algorithms.
  2. OpenSSL 3.x design philosophy — OpenSSL 3.x deliberately split providers into default (modern, safe algorithms) and legacy (old algorithms) precisely so that legacy algorithms are opt-in, not opt-out. The no-legacy configure flag reflects this intent.
  
  CRs-Fixed: 4558516