### PR TITLE
[Backport Wrynose] qcom-console-image: add fwupd

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -15,6 +15,7 @@ CORE_IMAGE_BASE_INSTALL += " \
 "
 
 CORE_IMAGE_EXTRA_INSTALL += " \
+    fwupd \
     libgomp \
     ${@bb.utils.contains('MACHINE_FEATURES', 'phone', 'modemmanager', '', d)} \
 "


### PR DESCRIPTION
Backport of #326

Install fwupd so the console image (and the images derived from it) can perform firmware updates. On EFI-capable machines this enables UEFI capsule updates, but fwupd is useful on every target: it can also update the firmware of connected peripherals (USB devices such as Logitech receivers, docks, NVMe drives, etc.), so install it unconditionally instead of gating it on the 'efi' MACHINE_FEATURE.

meta-oe, which provides the fwupd recipe, is already a LAYERDEPENDS of this layer, so no new layer dependency is required.
