### PR TITLE
qcom-console-image: gate m2 firmware by MACHINE_FEATURES

### DIFF
--- a/recipes-products/images/qcom-console-image.bb
+++ b/recipes-products/images/qcom-console-image.bb
@@ -18,4 +18,5 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     fwupd \
     libgomp \
     ${@bb.utils.contains('MACHINE_FEATURES', 'phone', 'modemmanager', '', d)} \
+    ${@bb.utils.contains('MACHINE_FEATURES', 'm2connector', 'packagegroup-qcom-m2-firmware', '', d)} \
 "


### PR DESCRIPTION
Install packagegroup-qcom-m2-firmware in qcom-console-image only when MACHINE_FEATURES contains m2connector.

This aligns the distro image behavior with machine definitions in meta-qcom, where m2connector is enabled for:
- rb3gen2-core-kit
- qcs615-ride
- iq-9075-evk

Using the feature flag keeps M.2 firmware installation scoped to boards that actually expose the customer M.2 connector.