### PR TITLE
qcom-multimedia-image: add firmware-qcom-boot-shikra to INCOMPATIBLE_LICENSE_EXCEPTIONS

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -27,6 +27,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-qcs9100:LICENSE.qcom-2 \
     firmware-qcom-boot-qrb2210:LICENSE.qcom-2 \
     firmware-qcom-boot-qrb2210-rb1:LICENSE.qcom \
+    firmware-qcom-boot-shikra:LICENSE.qcom-2 \
     firmware-qcom-boot-sm8750:LICENSE.qcom-2 \
     trusted-firmware-a-qcom:LICENSE.qcom \
 "


### PR DESCRIPTION
Add firmware-qcom-boot-shikra to INCOMPATIBLE_LICENSE_EXCEPTIONS list to allow it to be part of the image.