### PR TITLE
ci: drop redundant linux-qcom-6.18 kernel fragment

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -158,9 +158,6 @@ jobs:
           - type: default
             dirname: ""
             yamlfile: ""
-          - type: 6.18
-            dirname: "_linux-qcom-6.18"
-            yamlfile: ":ci/linux-qcom-6.18.yml"
           - type: rt-6.18
             dirname: "_linux-qcom-rt-6.18"
             yamlfile: ":ci/linux-qcom-rt-6.18.yml"
@@ -212,17 +209,17 @@ jobs:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:
-                type: u-boot-qcom-6.18
-                dirname: "_linux-qcom-6.18_u-boot-qcom"
-                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+                type: u-boot-qcom
+                dirname: "_u-boot-qcom"
+                yamlfile: ":ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit
             distro:
                 name: qcom-distro
                 yamlfile: ':ci/qcom-distro.yml'
             kernel:
-                type: u-boot-qcom-6.18
-                dirname: "_linux-qcom-6.18_u-boot-qcom"
-                yamlfile: ":ci/linux-qcom-6.18.yml:ci/u-boot-qcom.yml"
+                type: u-boot-qcom
+                dirname: "_u-boot-qcom"
+                yamlfile: ":ci/u-boot-qcom.yml"
           - machine: rb3gen2-core-kit-open-fw
             distro:
                 name: qcom-distro

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,6 @@ jobs:
           - name: qcom-distro
         kernel:
           - ""
-          - _linux-qcom-6.18
-        exclude:
-          - machine: qcom-armv7a
-            kernel: _linux-qcom-6.18
     steps:
       - uses: actions/checkout@v6
         with:
@@ -151,7 +147,6 @@ jobs:
           - name: qcom-distro
         kernel:
           - ""
-          - _linux-qcom-6.18
     steps:
       - id: print-condition
         name: "Print condition"

--- a/ci/linux-qcom-6.18.yml
+++ b/ci/linux-qcom-6.18.yml
@@ -1,6 +1,0 @@
-header:
-  version: 14
-  includes:
-    - ci/meta-qcom.yml
-    - repo: meta-qcom
-      file: ci/linux-qcom-6.18.yml


### PR DESCRIPTION
On the wrynose branch 6.18 is already the default linux-qcom kernel, so the explicit 6.18 build/test axis (which pinned the kernel via ci/linux-qcom-6.18.yml, itself an overlay onto meta-qcom's fragment) is redundant with the default builds.

- Remove ci/linux-qcom-6.18.yml.
- build-yocto.yml: drop the standalone "_linux-qcom-6.18" kernel matrix entry and rewrite the two u-boot-qcom matrix entries to compose only :ci/u-boot-qcom.yml, renaming their type/dirname accordingly.
- test.yml: drop the "_linux-qcom-6.18" kernel from both boot and pre-merge test matrices (and the now-orphaned qcom-armv7a exclude).

The separate RT fragment ci/linux-qcom-rt-6.18.yml is left untouched.