### PR TITLE
recipes-connectivity: disable NetworkManager-wait-online.service

### DIFF
--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,7 @@
+# Keep NetworkManager enabled, but avoid auto-enabling wait-online at boot.
+do_install:append() {
+    if [ -e ${D}${systemd_system_unitdir}/NetworkManager.service ]; then
+        sed -i '/^Also=NetworkManager-wait-online\.service[[:space:]]*$/d' \
+            ${D}${systemd_system_unitdir}/NetworkManager.service
+    fi
+}


### PR DESCRIPTION
Introduce a networkmanager bbappend to disable NetworkManager-wait- online.service.

NetworkManager-wait-online.service is auto-enabled via the "Also=" install hook in NetworkManager.service. However, it blocks startup and significantly increases boot time. Multiple targets have reported this issue, such as iq-615-evk and iq-8275-evk. Remove the install hook during do_install so wait-online is not enabled by default.

Measured boot time improvement on iq-615-evk target:
- before: ~28s
- after:  ~18s

qli-2.0 GA block issue