### PR TITLE
recipes-connectivity: disable IPv4 DAD timeout to reduce boot time

### DIFF
--- a/recipes-connectivity/networkmanager/files/20-no-acd.conf
+++ b/recipes-connectivity/networkmanager/files/20-no-acd.conf
@@ -1,0 +1,2 @@
+[connection-dad-default]
+ipv4.dad-timeout=0

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://20-no-acd.conf"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/NetworkManager/conf.d
+    install -m 0644 ${UNPACKDIR}/20-no-acd.conf ${D}${sysconfdir}/NetworkManager/conf.d/20-no-acd.conf
+}


### PR DESCRIPTION
NetworkManager-wait-online.service waits for network configuration to complete on interfaces, which can delay boot.

Install /etc/NetworkManager/conf.d/20-no-acd.conf via bbappend and set ipv4.dad-timeout=0 under [connection-dad-default] to avoid DAD wait time during IPv4 configuration, reducing overall boot time.