### PR TITLE
Sync ci/qcom-distro.yml with meta-qcom

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -43,7 +43,6 @@ repos:
 
   meta-security:
     url: https://git.yoctoproject.org/meta-security
-    branch: master
     layers:
       .:
       meta-tpm:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -29,7 +29,6 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/git/meta-virtualization
-    branch: master
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach


### PR DESCRIPTION
Backport missing patches:

[ci: qcom-distro: remove branch settings for meta-virtualization](https://github.com/qualcomm-linux/meta-qcom/commit/d0df6dfdd8f42135198f64fc381599335a5de3f2)

[ci: qcom-distro: remove branch settings for meta-security](https://github.com/qualcomm-linux/meta-qcom/commit/14fd3964a09738320b08a49a1a9c003343f99ed1)
