### PR TITLE
tensorflow-lite: fix label_image link failure with GCC 16

### DIFF
--- a/recipes-ml/tflite/files/tflite/0013-tflite-examples-label_image-build-profile_buffer.patch
+++ b/recipes-ml/tflite/files/tflite/0013-tflite-examples-label_image-build-profile_buffer.patch
@@ -1,0 +1,46 @@
+From 158c361a47de44003ff79a3f682319eca14db252 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Date: Tue, 16 Jun 2026 15:36:16 +0000
+Subject: [PATCH] tflite: examples: label_image: build profile_buffer.cc
+
+The label_image example uses BufferedProfiler (via profiler.h /
+buffered_profiler.h), whose EndEvent()/BeginEvent() forward to
+tflite::profiling::ProfileBuffer. ProfileBuffer is declared in
+profiling/profile_buffer.h and defined in profiling/profile_buffer.cc,
+which is deliberately excluded from libtensorflow-lite.a
+(TFLITE_PROFILER_SRCS in tensorflow/lite/CMakeLists.txt). Every tool
+that pulls in the profiler must therefore compile profile_buffer.cc
+itself - tools/benchmark/CMakeLists.txt already does, but the
+label_image example does not.
+
+This is a latent bug: older compilers inlined/eliminated the
+out-of-line reference to ProfileBuffer::EndEvent(), but GCC 16 keeps it,
+so linking label_image fails with:
+
+  undefined reference to
+  'tflite::profiling::ProfileBuffer::EndEvent(unsigned int,
+   long const*, long const*)'
+
+Add profiling/profile_buffer.cc to TFLITE_LABEL_IMAGE_SRCS, mirroring
+the benchmark_model target. Its other dependencies (time.cc,
+memory_info.cc and minimal logging) are already linked, so no further
+sources are needed.
+
+Upstream-Status: Submitted [https://github.com/tensorflow/tensorflow/pull/121367]
+
+Signed-off-by: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+---
+ tensorflow/lite/examples/label_image/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tensorflow/lite/examples/label_image/CMakeLists.txt b/tensorflow/lite/examples/label_image/CMakeLists.txt
+index ae4ab447064..cb9e0cbb310 100644
+--- a/tensorflow/lite/examples/label_image/CMakeLists.txt
++++ b/tensorflow/lite/examples/label_image/CMakeLists.txt
+@@ -25,2 +25,3 @@ list(APPEND TFLITE_LABEL_IMAGE_SRCS
+   ${TFLITE_SOURCE_DIR}/profiling/memory_info.cc
++  ${TFLITE_SOURCE_DIR}/profiling/profile_buffer.cc
+   ${TFLITE_SOURCE_DIR}/profiling/profile_summarizer.cc
+-- 
+2.43.0
+

--- a/recipes-ml/tflite/tensorflow-lite_2.16.1.bb
+++ b/recipes-ml/tflite/tensorflow-lite_2.16.1.bb
@@ -77,6 +77,7 @@ SRC_URI = " \
     file://tflite/0008-cmake-Add-install-rule-for-c-interface-shared-librar.patch \
     file://tflite/0009-tflite-Add-absl-log-dependency-for-enhanced-logging-.patch \
     file://tflite/2.16/0011-tflite-profiling-add-missing-cstdint-include.patch \
+    file://tflite/0013-tflite-examples-label_image-build-profile_buffer.patch \
     git://github.com/google/farmhash;name=farmhash;destsuffix=${S}/third_party/farmhash/;branch=master;protocol=https \
     git://github.com/google/gemmlowp.git;name=gemmlowp;destsuffix=${S}/third_party/gemmlowp/;branch=master;protocol=https \
     git://github.com/pytorch/cpuinfo.git;name=cpuinfo;destsuffix=${S}/third_party/cpuinfo/;branch=main;protocol=https \

--- a/recipes-ml/tflite/tensorflow-lite_2.20.0.bb
+++ b/recipes-ml/tflite/tensorflow-lite_2.20.0.bb
@@ -75,6 +75,7 @@ SRC_URI = " \
     file://tflite/2.20/0007-cmake-Fix-label-image-dependencies.patch \
     file://tflite/0008-cmake-Add-install-rule-for-c-interface-shared-librar.patch \
     file://tflite/0009-tflite-Add-absl-log-dependency-for-enhanced-logging-.patch \
+    file://tflite/0013-tflite-examples-label_image-build-profile_buffer.patch \
     git://github.com/google/farmhash;name=farmhash;destsuffix=tensorflow-lite-${TF_LITE_VERSION}/third_party/farmhash/;branch=master;protocol=https \
     git://github.com/google/gemmlowp.git;name=gemmlowp;destsuffix=tensorflow-lite-${TF_LITE_VERSION}/third_party/gemmlowp/;branch=master;protocol=https \
     git://github.com/pytorch/cpuinfo.git;name=cpuinfo;destsuffix=tensorflow-lite-${TF_LITE_VERSION}/third_party/cpuinfo/;branch=main;protocol=https \


### PR DESCRIPTION
Linking the label_image example fails with the newer GCC 16 toolchain for both the 2.16.1 and 2.20.0 recipes:

  undefined reference to 'tflite::profiling::ProfileBuffer::EndEvent(
    unsigned int, long const*, long const*)'
  collect2: error: ld returned 1 exit status

label_image uses BufferedProfiler, which forwards to tflite::profiling::ProfileBuffer. ProfileBuffer is defined in profiling/profile_buffer.cc, which is excluded from libtensorflow-lite.a, so each tool must compile it - benchmark_model does, but the label_image example does not. Older compilers inlined away the out-of-line reference to EndEvent(); GCC 16 keeps it, exposing the missing source.

Add a patch adding profiling/profile_buffer.cc to the label_image sources, mirroring the benchmark_model target. No upstream fix exists yet (tensorflow/tensorflow master still omits it), so carry it locally.

The example's source list is identical across 2.16.x and 2.20.x in the relevant region, so the patch uses minimal context and is shared from recipes-ml/tflite/files/tflite/ by both recipes to avoid duplication.