### PR TITLE
qcom-minimal-image: empty /boot so the ESP can be mounted there

### DIFF
--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -35,4 +35,14 @@ python __anonymous() {
         d.setVar("KERNEL_DEVICETREE", "")
 }
 
+# On EFI machines the system boots via the ESP partition and UKIs, so the
+# kernel/loader files staged in /boot are unused; remove them so /boot is an
+# empty mountpoint and systemd can mount the ESP there at runtime.
+clean_boot_mountpoint() {
+    if [ -d ${IMAGE_ROOTFS}/boot ]; then
+        find ${IMAGE_ROOTFS}/boot -mindepth 1 -delete
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('MACHINE_FEATURES', 'efi', 'clean_boot_mountpoint ', '', d)}"
+
 BAD_RECOMMENDATIONS += "systemd-networkd"

--- a/recipes-products/images/qcom-minimal-image.bb
+++ b/recipes-products/images/qcom-minimal-image.bb
@@ -35,4 +35,13 @@ python __anonymous() {
         d.setVar("KERNEL_DEVICETREE", "")
 }
 
+# On EFI machines the system boots via the ESP partition and UKIs, so the
+# kernel/loader files staged in /boot are unused; remove them so /boot is an
+# empty mountpoint and systemd can mount the ESP there at runtime.
+clean_boot_mountpoint() {
+    rm -rf "${IMAGE_ROOTFS}/boot"
+    mkdir "${IMAGE_ROOTFS}/boot"
+}
+ROOTFS_POSTPROCESS_COMMAND += "${@bb.utils.contains('MACHINE_FEATURES', 'efi', 'clean_boot_mountpoint ', '', d)}"
+
 BAD_RECOMMENDATIONS += "systemd-networkd"


### PR DESCRIPTION
On EFI machines the system boots from the ESP partition via UKIs, so the kernel and boot loader entries staged in /boot of the rootfs are never used. Worse, a non-empty /boot prevents systemd from mounting the ESP there at runtime.

Empty /boot at rootfs postprocess time, keeping the directory itself as the mountpoint. Guard on the efi machine feature, matching the ESP image's own gating, since on non-EFI machines /boot may be the real boot path.

This also aligns the regular images with the OTA-enabled ones, where meta-updater already splits the boot content out of the rootfs and ships an empty /boot. The cleanup is a no-op for the sota pipeline, which discards the rootfs /boot content on its own.