### PR TITLE
recipes-connectivity: networkmanager: override wait-online ExecStart

### DIFF
--- a/recipes-connectivity/networkmanager/files/override.conf
+++ b/recipes-connectivity/networkmanager/files/override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/bin/nm-online -q

--- a/recipes-connectivity/networkmanager/networkmanager_%.bbappend
+++ b/recipes-connectivity/networkmanager/networkmanager_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:qcom-distro = "file://override.conf"
+
+do_install:append:qcom-distro() {
+        install -d ${D}${systemd_system_unitdir}/NetworkManager-wait-online.service.d
+        install -m 0644 ${WORKDIR}/sources/override.conf \
+            ${D}${systemd_system_unitdir}/NetworkManager-wait-online.service.d/override.conf
+}


### PR DESCRIPTION
Install a systemd drop-in for NetworkManager-wait-online.service and
override ExecStart to use:

    /usr/bin/nm-online -q

The ExecStart was "/usr/bin/nm-online -s -q" before and it waited for
startup completion. This means wait-online service will wait for all
interface connection completing. This behavior will increase boot time.

With this behavior, wait-online service will unblock once any interface
connection completing so that improving boot time. It is observed that
10-12s boot time improvement across targets.

GA-block issue