### PR TITLE
packagegroup-qcom-virtualization: restrict qemu to 64-bit hosts

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-virtualization.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-virtualization.bb
@@ -7,5 +7,9 @@ RDEPENDS:${PN} += " \
     libvirt \
     libvirt-libvirtd \
     libvirt-virsh \
+    "
+
+# qemu 11.0.0 only supports 64-bit hosts
+RDEPENDS:${PN}:append:aarch64 = " \
     qemu \
     "


### PR DESCRIPTION
oe-core's qemu recipe dropped support for 32-bit hosts by limiting its
COMPATIBLE_HOST (in qemu.inc) to 64-bit architectures (part of the qemu
11.0.0 update in oe-core). On 32-bit targets such as arm-qcom-linux-gnueabi
qemu is now skipped, which broke the build of any image pulling in this
packagegroup:

  ERROR: Nothing RPROVIDES 'qemu' (but packagegroup-qcom-virtualization.bb
  RDEPENDS on or otherwise requires it)

Move qemu into an aarch64-only RDEPENDS append so the packagegroup remains
buildable on 32-bit targets while still pulling in qemu where it is supported.
The remaining libvirt dependencies stay arch-agnostic.