### PR TITLE
recipes-products: images: Add RTSS Mailbox KMD and UMD packages

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -18,6 +18,9 @@ CORE_IMAGE_BASE_INSTALL += " \
     iris-video-dlkm \
     kgsl-dlkm \
     qcom-rtss-mailbox-kmd \
+    qcom-rtss-mailbox-umd \
+    qcom-rtss-ota \
+    qcom-rtss-mailbox-umd-utils \
     libdiag-bin \
     qcom-adreno \
     qcom-sensors-binaries \

--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -17,6 +17,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     gst-plugins-imsdk-prop \
     iris-video-dlkm \
     kgsl-dlkm \
+    qcom-rtss-mailbox-kmd \
     libdiag-bin \
     qcom-adreno \
     qcom-sensors-binaries \


### PR DESCRIPTION
Add RTSS Mailbox kernel and userspace packages to qcom-multimedia-proprietary-image.

  - qcom-rtss-mailbox-kmd: kernel driver module
  - qcom-rtss-mailbox-umd: userspace middleware libraries
  - qcom-rtss-ota: OTA SDK library
  - qcom-rtss-mailbox-umd-utils: debug utilities (rtssdbg, rtss_console, rtss_mbdemo)