### PR TITLE
weston-init: add display-ready drop-in to delay Weston startup

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -1,7 +1,20 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI:append:qcom-distro = " file://weston-terminal.ini"
+SRC_URI:append:qcom-distro = " \
+    file://weston-terminal.ini \
+    file://weston.service.d/display-ready.conf \
+    file://99-drm-systemd.rules \
+"
 
 do_install:append:qcom-distro() {
     cat ${WORKDIR}/sources/weston-terminal.ini >> ${D}${sysconfdir}/xdg/weston/weston.ini
+    install -d ${D}${systemd_system_unitdir}/weston.service.d
+    install -m 0644 ${WORKDIR}/sources/weston.service.d/display-ready.conf \
+        ${D}${systemd_system_unitdir}/weston.service.d/display-ready.conf
+    install -d ${D}${nonarch_base_libdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/sources/99-drm-systemd.rules \
+        ${D}${nonarch_base_libdir}/udev/rules.d/99-drm-systemd.rules
 }
+
+FILES:${PN}:append:qcom-distro = " ${systemd_system_unitdir}/weston.service.d/display-ready.conf"
+FILES:${PN}:append:qcom-distro = " ${nonarch_base_libdir}/udev/rules.d/99-drm-systemd.rules"

--- a/recipes-graphics/wayland/weston-init/99-drm-systemd.rules
+++ b/recipes-graphics/wayland/weston-init/99-drm-systemd.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="drm", KERNEL=="card0", TAG+="systemd"

--- a/recipes-graphics/wayland/weston-init/weston.service.d/display-ready.conf
+++ b/recipes-graphics/wayland/weston-init/weston.service.d/display-ready.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=dev-dri-card0.device
+Wants=dev-dri-card0.device


### PR DESCRIPTION
The display subsystem on some Qualcomm platforms needs additional
time to fully settle after the DRM module loads before Weston can
successfully initialize its DRM backend.

Add a display-ready.conf drop-in for weston.service that introduces
a short startup delay, preventing Weston from attempting to acquire
the display before the hardware is ready.

Tested on IQ-8275 EVK (QCS8300).

Signed-off-by: Raul Munoz <raulrm@qti.qualcomm.com>