### PR TITLE
aktualizr: do not auto-start the SOTA client services on boot

### DIFF
--- a/recipes-sota/aktualizr/aktualizr_%.bbappend
+++ b/recipes-sota/aktualizr/aktualizr_%.bbappend
@@ -1,0 +1,3 @@
+# meta-qcom-distro does not provision an OTA service backend by default
+SYSTEMD_AUTO_ENABLE:${PN}:qcom-distro = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}-secondary:qcom-distro = "disable"


### PR DESCRIPTION
meta-qcom-distro does not provision an OTA service backend for the reference image, so aktualizr has no valid HTTP service endpoint to connect to. Aktualizr inherits the systemd class default (SYSTEMD_AUTO_ENABLE ??= "enable"), so both aktualizr.service and aktualizr-secondary.service would otherwise start at boot. The daemon stays up and just spins in an update loop where every cycle fails for lack of a connection, with no server to talk to.

Disable both services by default for qcom-distro. Once the device is registered and its credentials are available locally, the user can enable the services manually.