### PR TITLE
libvirt: drop qemu PACKAGECONFIG on 32-bit arm hosts

### DIFF
--- a/recipes-extended/libvirt/libvirt_git.bbappend
+++ b/recipes-extended/libvirt/libvirt_git.bbappend
@@ -1,0 +1,3 @@
+# QEMU 11.0.0+ requires 64-bit host architecture
+# https://lists.yoctoproject.org/g/meta-virtualization/message/9893
+PACKAGECONFIG:remove:qcom-distro:arm = "qemu"


### PR DESCRIPTION
oe-core's qemu recipe dropped support for 32-bit hosts by limiting its COMPATIBLE_HOST (in qemu.inc) to 64-bit architectures (part of the qemu 11.0.0 update in oe-core). libvirt's default PACKAGECONFIG enables the qemu driver, which depends on qemu, so on 32-bit targets such as arm-qcom-linux-gnueabi the libvirt build now breaks because qemu is no longer provided.

Remove qemu from PACKAGECONFIG via a qcom-distro arm override so libvirt remains buildable on 32-bit targets, while 64-bit hosts keep the qemu driver. See:

  https://lists.yoctoproject.org/g/meta-virtualization/message/9893

This local workaround can be reverted once the patch is accepted in meta-virtualization.