### PR TITLE
README: document the wrynose LTS branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ revision: HEAD
 
 - **main:** Primary development branch, with focus on upstream support and
   compatibility with the most recent Yocto Project release.
+- **wrynose:** Qualcomm Linux 2.x, aligned with Yocto Project 6.0 (LTS).
 - **scarthgap:** Qualcomm Linux >= 1.4, aligned with Yocto Project 5.0 (LTS).
 - **kirkstone:** Qualcomm Linux <= 1.3, aligned with Yocto Project 4.0 (LTS).
 


### PR DESCRIPTION
Add the wrynose branch to the Branches section. It tracks the Yocto Project 6.0 LTS release (codename "wrynose"), used by Qualcomm Linux 2.x.