### PR TITLE
ci/qcom-distro: update the URL for meta-virtualization

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -28,7 +28,7 @@ repos:
     branch: main
 
   meta-virtualization:
-    url: https://git.yoctoproject.org/git/meta-virtualization
+    url: https://git.yoctoproject.org/meta-virtualization
 
   meta-audioreach:
     url: https://github.com/AudioReach/meta-audioreach


### PR DESCRIPTION
Using https://git.yoctoproject.org/git/meta-virtualization generates fetching errors from time to time. Follow other Yocto Project repositories and use https://git.yoctoproject.org/meta-virtualization as a URL.