### PR TITLE
Adds qcom-rtss-can to qcom-multimedia-proprietary-image.

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -19,6 +19,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     kgsl-dlkm \
     libdiag-bin \
     qcom-adreno \
+    qcom-rtss-can \
     qcom-sensors-binaries \
     qwes \
 "


### PR DESCRIPTION
Add qcom-rtss-can to qcom-multimedia-proprietary-image.

qcom-rtss-can is a userspace daemon that bridges Linux SocketCAN
interfaces with RTSS mailbox channels, enabling standard SocketCAN
applications to reach CAN hardware managed by the RTSS (Real-Time
SubSystem).

Depends on:
- qualcomm-linux/meta-qcom-distro#355 (RTSS mailbox KMD/UMD packages)
- qualcomm-linux/meta-qcom#2644 (qcom-rtss-can recipe)

