### PR TITLE
[Wrynose] refpolicy-targeted: Allow BPF usage for NetworkManager IPv4 ACD

### DIFF
--- a/recipes-security/refpolicy/refpolicy-targeted/0001-Allow-network-manager-to-use-bpf-for-IPv4-collision-.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/0001-Allow-network-manager-to-use-bpf-for-IPv4-collision-.patch
@@ -1,0 +1,33 @@
+From 6a84386d1c69817d47f9e9a7d744167ad8c92f82 Mon Sep 17 00:00:00 2001
+From: Russell Coker <russell@coker.com.au>
+Date: Fri, 12 Jun 2026 00:16:58 +1000
+Subject: [PATCH] Allow network manager to use bpf for IPv4 collision
+ detection, see the following:
+
+https://bugzilla.redhat.com/show_bug.cgi?id=1651654
+
+Upstream-Status: Backport [6a84386d1c69817d47f9e9a7d744167ad8c92f82]
+Signed-off-by: Russell Coker <russell@coker.com.au>
+---
+ policy/modules/services/networkmanager.te | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/policy/modules/services/networkmanager.te b/policy/modules/services/networkmanager.te
+index 79be9de59..ed240522e 100644
+--- a/policy/modules/services/networkmanager.te
++++ b/policy/modules/services/networkmanager.te
+@@ -44,9 +44,10 @@ init_system_domain(wpa_cli_t, wpa_cli_exec_t)
+ 
+ allow NetworkManager_t self:capability { chown dac_override dac_read_search fowner fsetid ipc_lock kill net_admin net_raw setgid setuid sys_nice };
+ dontaudit NetworkManager_t self:capability { sys_module sys_ptrace sys_tty_config };
+-allow NetworkManager_t self:capability2 wake_alarm;
++allow NetworkManager_t self:capability2 { wake_alarm bpf };
+ allow NetworkManager_t self:process { getcap getsched ptrace setcap setpgid setsched signal_perms };
+ allow NetworkManager_t self:fifo_file rw_fifo_file_perms;
++allow NetworkManager_t self:bpf { prog_run prog_load map_create map_read map_write };
+ allow NetworkManager_t self:unix_dgram_socket sendto;
+ allow NetworkManager_t self:unix_stream_socket { accept listen };
+ allow NetworkManager_t self:netlink_route_socket create_netlink_socket_perms;
+-- 
+2.43.0
+

--- a/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " \
+    file://0001-Allow-network-manager-to-use-bpf-for-IPv4-collision-.patch \
+"


### PR DESCRIPTION
NetworkManager uses BPF programs for IPv4 Address Conflict Detection (ACD). This requires the ability to load and execute BPF programs as well as create and access BPF maps.

Without these permissions, SELinux denies operations such as prog_load and map_create, preventing ACD from functioning. And then NetworkManager falls back to slower ACD behavior, which can delay WLAN connection and extend boot time when Wi-Fi connection is required during startup.

Backport the upstream SELinux policy update to grant the necessary BPF class permissions to NetworkManager_t.

Reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1651654

Note:
For the master branch of meta-selinux, the commit-7351443 has included this patch. And the main branch of meta-qcom has updated the rev of meta-selinux to include commit-7351443 in PR#2647 and this issue will be fixed. Thus, this patch do not need to apply into the main branch.

But for the wrynose branch of meta-selinux, the maintainer do not have the plan to apply this patch temporarily. Thus, to fix this issue on wrynose branch, we need to submit code changes separately. When the maintainer of meta-selinux updates this patch into wrynose branch, this commit will be reverted.