### PR TITLE
qcom-base.inc: bump DISTRO_VERSION to 2.99+snapshot post release

### DIFF
--- a/conf/distro/include/qcom-base.inc
+++ b/conf/distro/include/qcom-base.inc
@@ -1,9 +1,10 @@
 DISTRO_NAME = "Qualcomm Linux Reference Distro"
 
-DISTRO_VERSION = "2.0"
+DISTRO_VERSION = "2.99+snapshot-${METADATA_REVISION}"
 
 # SDK variables.
-SDK_VERSION = "${DISTRO_VERSION}"
+SDK_VERSION = "${@d.getVar('DISTRO_VERSION').replace('snapshot-${METADATA_REVISION}', 'snapshot')}"
+SDK_VERSION[vardepvalue] = "${SDK_VERSION}"
 SDK_NAME = "${DISTRO}-${SDKMACHINE}-${IMAGE_BASENAME}-${TUNE_PKGARCH}-${MACHINE}"
 SDK_VENDOR = "-qcomsdk"
 


### PR DESCRIPTION
The 2.0 release is maintained in the wrynose branch, so bump the development version on main to a post-release snapshot to make it clear this metadata is no longer based on the 2.0 release.

Set DISTRO_VERSION to "2.99+snapshot-${METADATA_REVISION}" so builds carry the metadata git revision, following the same convention used by poky.conf in meta-yocto.

Now that DISTRO_VERSION embeds the volatile METADATA_REVISION, adjust SDK_VERSION accordingly, as done in meta-yocto commit dc719ee8 ("poky: Set SDK_VERSION explicitly"):

- Derive SDK_VERSION from DISTRO_VERSION with the "snapshot-<revision>" suffix collapsed back to a stable "snapshot", so the SDK version does not carry the changing git revision.
- Pin SDK_VERSION[vardepvalue] so the SDK task signature only changes when the resulting value changes, rather than being invalidated on every metadata revision bump.

This is based on the meta-yocto poky.conf approach.