### PR TITLE
qcom-networking-image: add rtc-testbench

### DIFF
--- a/recipes-products/images/qcom-networking-image.bb
+++ b/recipes-products/images/qcom-networking-image.bb
@@ -3,5 +3,6 @@ require qcom-console-image.bb
 SUMMARY = "Image with Networking features"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    rtc-testbench \
     sigma-dut \
 "


### PR DESCRIPTION
Add rtc-testbench to the networking image to support real-time communication and TSN network validation use cases.