### PR TITLE
refpolicy-targeted: enable PipeWire system-service mode for Qualcomm

### DIFF
--- a/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -5,3 +5,5 @@ SRC_URI:append:qcom-distro = " \
     file://0003-wayland-Label-sockets-under-run-with-wayland_runtime.patch \
     file://0004-docker-Add-tunable-gated-optional-policy-for-dockerd.patch \
 "
+
+POLICY_CUSTOM_BUILDOPT:append:qcom-distro = " pipewire_system_service"


### PR DESCRIPTION
The upstream PipeWire SELinux policy has been merged into refpolicy (SELinuxProject/refpolicy#1109).
Set POLICY_CUSTOM_BUILDOPT to pipewire_system_service so that PipeWire runs as a system-wide daemon on Qualcomm embedded targets.