### PR TITLE
packagegroup-qcom-utilities: add boot-time-analysis-tools

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -74,6 +74,8 @@ RDEPENDS:${PN}-profile-utils = " \
     sysbench \
     ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd-analyze', '', d)} \
     tiobench \
+    boot-time-analysis-tools \
+    cntvct-log \
     "
 
 RDEPENDS:${PN}-support-utils = " \

--- a/recipes-support/boot-time-analysis-tools/boot-time-analysis-tools_git.bb
+++ b/recipes-support/boot-time-analysis-tools/boot-time-analysis-tools_git.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Boot time analysis tools from CentOS Automotive SIG"
+DESCRIPTION = "Tools for analyzing and visualizing system boot time"
+HOMEPAGE = "https://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1c2e0cc0dec0b709fe547806b55737b0"
+
+# Fetch from GitLab over HTTPS
+SRC_URI = "git://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools.git;protocol=https;branch=main"
+
+# Pin to a specific commit (get this from GitLab → Repository → Commits)
+SRCREV = "2409ce37e7389d8079bdb8740cb6a44b505fb8d4"
+
+# Source directory after fetch
+#S = "${WORKDIR}/git"
+
+# If it's Python-based:
+inherit setuptools3 systemd
+
+# Or if it's just scripts with no build system:
+# inherit allarch
+
+#do_install() {
+#        install -d ${D}${bindir}
+#        install -m 0755 ${S}/boot-time-analysis ${D}${bindir}/
+#        # Add other scripts/tools as needed
+#}
+
+# Runtime dependency on Python 3
+RDEPENDS:${PN} = "python3 python3-dbus python3-systemd python3-misc"

--- a/recipes-support/boot-time-analysis-tools/cntvct-log_git.bb
+++ b/recipes-support/boot-time-analysis-tools/cntvct-log_git.bb
@@ -1,0 +1,29 @@
+SUMMARY = "cntvct-log - ARM virtual counter boot time logger"
+DESCRIPTION = "Userspace tool to log ARM CNTVCT_EL0 counter values for boot time analysis"
+HOMEPAGE = "https://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=1c2e0cc0dec0b709fe547806b55737b0"
+
+SRC_URI = "git://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools.git;protocol=https;branch=main"
+SRCREV = "2409ce37e7389d8079bdb8740cb6a44b505fb8d4"
+
+# Point S to the cntvct-log subdirectory (subdirectory override is allowed in Scarthgap+)
+#S = "${UNPACKDIR}/git/cntvct-log"
+S = "${UNPACKDIR}/cntvct-log-git/cntvct-log"
+
+inherit meson pkgconfig systemd
+
+# Manually install service file if meson.build doesn't handle it
+do_install:append() {
+    if [ -f ${S}/usr/lib/systemd/system/cntvct@.service ]; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${S}/usr/lib/systemd/system/cntvct@.service \
+            ${D}${systemd_system_unitdir}/cntvct@.service
+    fi
+}
+
+SYSTEMD_SERVICE:${PN} = "cntvct@.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+# Explicitly include the service file in the package
+FILES:${PN} += "${systemd_system_unitdir}/cntvct@.service"


### PR DESCRIPTION
Add two new recipes from the CentOS Automotive SIG boot-time-analysis-tools project to enable boot time profiling and measurement on Qualcomm platforms.

boot-time-analysis-tools:
  Python-based toolset for collecting, analyzing and visualizing system
  boot timing data from the systemd journal. Provides the 'boot_timings'
  CLI utility which queries D-Bus and the systemd journal to produce
  structured boot time reports. Depends on python3-dbus and python3-systemd
  for runtime journal and D-Bus access.

  Usage: boot_timings --help

cntvct-log:
  Userspace C utility built with Meson that logs ARM CNTVCT_EL0 virtual
  counter timestamps to correlate hardware-level timing with systemd boot
  events. Installs cntvct@.service as a systemd template unit (disabled
  by default) for on-demand per-instance activation. The service preset
  file (98-cntvct-log.preset) is installed for system-preset-based enablement.

  Usage: 1. systemctl enable cntvct@basic.service # Reboot and check journalctl
         2. cntvct  # Prints absolute hw-level time (in secs) since device boot

Both recipes fetch from the same upstream git repository:
  https://gitlab.com/CentOS/automotive/src/boot-time-analysis-tools