### PR TITLE
qcom-networking-image: add linuxptp

### DIFF
--- a/recipes-products/images/qcom-networking-image.bb
+++ b/recipes-products/images/qcom-networking-image.bb
@@ -3,6 +3,7 @@ require qcom-console-image.bb
 SUMMARY = "Image with Networking features"
 
 CORE_IMAGE_BASE_INSTALL += " \
+    linuxptp \
     rtc-testbench \
     sigma-dut \
 "


### PR DESCRIPTION
Add linuxptp to the networking image to support PTP clock synchronization for time-sensitive networking validation.