### PR TITLE
packagegroup-qcom-utilities: add iproute2-tc

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-utilities.bb
@@ -56,6 +56,7 @@ RDEPENDS:${PN}-network-utils = " \
     hostapd \
     iperf2 \
     iproute2 \
+    iproute2-tc \
     iw \
     networkmanager \
     openssh-scp \


### PR DESCRIPTION
Add the traffic control utility split package alongside iproute2 so networking images include tc for queueing discipline and TSN traffic configuration.