### PR TITLE
weston-init: add weston user to fastrpc and dmaheap groups

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -4,6 +4,7 @@ SRC_URI:append:qcom-distro = " \
     file://weston-terminal.ini \
     file://qcom-background.ini \
     file://qcom-background.png \
+    file://weston-groups.conf \
 "
 
 do_install:append:qcom-distro() {
@@ -12,6 +13,12 @@ do_install:append:qcom-distro() {
     install -d ${D}${datadir}/backgrounds
     install -m 0644 ${S}/qcom-background.png \
         ${D}${datadir}/backgrounds/qcom-background.png
+    install -d ${D}${systemd_system_unitdir}/weston.service.d
+    install -m 0644 ${S}/weston-groups.conf \
+        ${D}${systemd_system_unitdir}/weston.service.d/weston-groups.conf
 }
 
-FILES:${PN}:append:qcom-distro = " ${datadir}/backgrounds/qcom-background.png"
+FILES:${PN}:append:qcom-distro = " \
+    ${datadir}/backgrounds/qcom-background.png \
+    ${systemd_unitdir}/system/weston.service.d/weston-groups.conf \
+"

--- a/recipes-graphics/wayland/weston-init/weston-groups.conf
+++ b/recipes-graphics/wayland/weston-init/weston-groups.conf
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+# Allow weston user to access FastRPC and DMA-HEAP devices
+
+[Service]
+SupplementaryGroups=fastrpc dmaheap


### PR DESCRIPTION
Child processes launched from the Weston compositor (e.g. QDEMO) inherit the weston user's credentials. Without supplementary group membership they cannot access camera buffers (dmaheap) or CDSP/NSP nodes (fastrpc).

Install a systemd drop-in weston.service.d/weston-groups.conf that adds fastrpc and dmaheap as supplementary groups to weston.service, fixing device access for all apps spawned from the Wayland session.