### PR TITLE
qcom-multimedia-image: add gst-plugins-imsdk-python

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -41,7 +41,7 @@ CORE_IMAGE_BASE_INSTALL += " \
 "
 
 # IMSDK currently only used and tested on ARMv8 (aarch64) machines.
-CORE_IMAGE_BASE_INSTALL:append:aarch64 = " gst-plugins-imsdk-oss"
+CORE_IMAGE_BASE_INSTALL:append:aarch64 = " gst-plugins-imsdk-oss gst-plugins-imsdk-python"
 
 # let's make sure we have a good image.
 REQUIRED_DISTRO_FEATURES += "wayland"


### PR DESCRIPTION
Add IMSDK python extension module to provide support in Python for accessing C objects, structures and APIs from IMSDK base.

[Related to PR 2735](https://github.com/qualcomm-linux/meta-qcom/pull/2735)