### PR TITLE
[Backport wrynose] selinux: Add CDI access, Wayland interface and labeling, and tunable dockerd integration

### DIFF
--- a/recipes-security/refpolicy/refpolicy-targeted/0002-wayland-Add-wayland_stream_connect-interface.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/0002-wayland-Add-wayland_stream_connect-interface.patch
@@ -1,0 +1,55 @@
+From 86ee8eb9fb4226ba11e02254b12278c9de446f8a Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Fri, 19 Jun 2026 13:30:02 +0300
+Subject: [PATCH 2/3] wayland: Add wayland_stream_connect interface
+
+Add a new interface, wayland_stream_connect(), to allow domains to
+connect to a Wayland compositor via a UNIX stream socket.
+
+This interface grants the necessary permissions to search the user
+runtime directory and establish a stream connection to Wayland
+compositor sockets labeled with wayland_runtime_t.
+
+Typical usage includes enabling confined domains (such as container
+runtimes or applications) to communicate with the Wayland display server.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1166]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/session/wayland.if | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/policy/modules/session/wayland.if b/policy/modules/session/wayland.if
+index 2812dcb30..bc4185c2a 100644
+--- a/policy/modules/session/wayland.if
++++ b/policy/modules/session/wayland.if
+@@ -99,3 +99,25 @@ interface(`wayland_client_sandboxed_domain',`
+ 
+ 	typeattribute $1 wayland_client_sandboxed;
+ ')
++
++#########################################
++## <summary>
++##	Connect to the Wayland compositor
++##	using a UNIX domain stream socket.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`wayland_stream_connect',`
++	gen_require(`
++		type wayland_runtime_t;
++	')
++
++	files_search_runtime($1)
++	userdom_search_user_runtime($1)
++	allow $1 wayland_runtime_t:sock_file write_sock_file_perms;
++	allow $1 wayland_runtime_t:unix_stream_socket connectto;
++')
+-- 
+2.43.0
+

--- a/recipes-security/refpolicy/refpolicy-targeted/0003-wayland-Label-sockets-under-run-with-wayland_runtime.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/0003-wayland-Label-sockets-under-run-with-wayland_runtime.patch
@@ -1,0 +1,31 @@
+From d4a85ae3abdbac8065b6389a103723755866af2c Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Mon, 22 Jun 2026 15:49:44 +0300
+Subject: [PATCH 3/3] wayland: Label sockets under /run with wayland_runtime_t
+
+On some embedded or single-user systems the Wayland socket
+(e.g. wayland-0) is created directly under /run instead of
+/run/user/<uid>/. The existing policy only covers per-user runtime
+directories, leaving these sockets unlabeled.
+
+Add a file context rule for /run/wayland-* to ensure such sockets are
+correctly labeled with wayland_runtime_t, aligning behavior across
+different system configurations.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1166]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/session/wayland.fc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/policy/modules/session/wayland.fc b/policy/modules/session/wayland.fc
+index 73151efba..bd2ccc08e 100644
+--- a/policy/modules/session/wayland.fc
++++ b/policy/modules/session/wayland.fc
+@@ -1 +1,2 @@
+ /run/user/%{USERID}/wayland-.*	-s	gen_context(system_u:object_r:wayland_runtime_t,s0)
++/run/wayland-.*		-s	gen_context(system_u:object_r:wayland_runtime_t,s0)
+-- 
+2.43.0
+

--- a/recipes-security/refpolicy/refpolicy-targeted/0004-docker-Add-tunable-gated-optional-policy-for-dockerd.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/0004-docker-Add-tunable-gated-optional-policy-for-dockerd.patch
@@ -1,0 +1,81 @@
+From fa9fde3e037f395cd2ecc10cc86aa5f413c4528c Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Fri, 19 Jun 2026 13:43:44 +0300
+Subject: [PATCH 4/4] docker: Add tunable-gated optional policy for dockerd
+ access to user session services
+
+Introduce a new tunable to control whether the Docker daemon (dockerd_t)
+may connect to user session services over UNIX stream sockets.
+
+This change adds the following interfaces:
+
+    pulseaudio_stream_connect(dockerd_t)
+    wayland_stream_connect(dockerd_t)
+
+These permissions allow dockerd to communicate with PulseAudio and Wayland compositor
+sockets typically located under /run/user/$UID, which is required for certain container
+workloads that need access to the host audio or graphical display.
+
+The access is gated behind a new tunable:
+
+    dockerd_connect_user_services (default: off)
+
+When enabled, the rules are applied via tunable_policy(), providing
+administrators explicit control using setsebool.
+
+Both interfaces remain wrapped in optional_policy blocks to ensure the
+policy compiles and applies cleanly only when the corresponding PulseAudio
+and Wayland policy modules are present.
+
+This approach improves compatibility with containerized desktop workloads
+while maintaining secure-by-default behavior and modular SELinux policy design.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1167]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/services/docker.te | 21 +++++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/policy/modules/services/docker.te b/policy/modules/services/docker.te
+index f40713d12..cf45fc188 100644
+--- a/policy/modules/services/docker.te
++++ b/policy/modules/services/docker.te
+@@ -5,6 +5,15 @@ policy_module(docker)
+ # Declarations
+ #
+ 
++## <desc>
++##	<p>
++##	Determine whether the Docker daemon can connect to user
++##	session services such as PulseAudio and Wayland over
++##	UNIX stream sockets.
++##	</p>
++## </desc>
++gen_tunable(dockerd_connect_user_services, false)
++
+ container_engine_domain_template(dockerd)
+ container_system_engine(dockerd_t)
+ optional_policy(`
+@@ -77,6 +86,18 @@ ifdef(`init_systemd',`
+ 	init_stop_generic_units(dockerd_t)
+ ')
+ 
++optional_policy(`
++	tunable_policy(`dockerd_connect_user_services',`
++		pulseaudio_stream_connect(dockerd_t)
++	')
++')
++
++optional_policy(`
++	tunable_policy(`dockerd_connect_user_services',`
++		wayland_stream_connect(dockerd_t)
++	')
++')
++
+ ########################################
+ #
+ # Docker CLI local policy
+-- 
+2.43.0
+

--- a/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -4,4 +4,5 @@ SRC_URI:append:qcom-distro = " \
     file://0001-Allow-network-manager-to-use-bpf-for-IPv4-collision-.patch \
     file://0002-wayland-Add-wayland_stream_connect-interface.patch \
     file://0003-wayland-Label-sockets-under-run-with-wayland_runtime.patch \
+    file://0004-docker-Add-tunable-gated-optional-policy-for-dockerd.patch \
 "

--- a/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -2,4 +2,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom-distro = " \
     file://0001-Allow-network-manager-to-use-bpf-for-IPv4-collision-.patch \
+    file://0002-wayland-Add-wayland_stream_connect-interface.patch \
+    file://0003-wayland-Label-sockets-under-run-with-wayland_runtime.patch \
 "


### PR DESCRIPTION
Backport of #358  to wrynose