### PR TITLE
recipes-multimedia: Add D-Bus system bus policy for bluez5 native Telephony service

### DIFF
--- a/recipes-multimedia/audio/files/bluetooth.conf
+++ b/recipes-multimedia/audio/files/bluetooth.conf
@@ -1,0 +1,6 @@
+## Move the BlueZ5 native backend's Telephony D-Bus service to the system
+## bus, since no session bus is available when wireplumber.service runs
+## in system-wide mode.
+monitor.bluez.properties = {
+  bluez5.telephony.use-system-bus = true
+}

--- a/recipes-multimedia/audio/wireplumber_%.bbappend
+++ b/recipes-multimedia/audio/wireplumber_%.bbappend
@@ -1,3 +1,22 @@
 # Enable wireplumber as a system-wide service
 SYSTEMD_SERVICE:${PN}:qcom-distro = "wireplumber.service"
 SYSTEMD_AUTO_ENABLE:${PN}:qcom-distro = "enable"
+
+FILESEXTRAPATHS:prepend:qcom-distro := "${THISDIR}/files:"
+
+SRC_URI:append:qcom-distro = " \
+    file://bluetooth.conf \
+"
+
+do_install:append:qcom-distro() {
+    install -Dm 0644 ${UNPACKDIR}/bluetooth.conf \
+            ${D}${datadir}/wireplumber/wireplumber.conf.d/bluetooth.conf
+}
+
+FILES:${PN}:append:qcom-distro = " \
+    ${datadir}/wireplumber/wireplumber.conf.d/bluetooth.conf \
+"
+
+CONFFILES:${PN}:append:qcom-distro = " \
+    ${datadir}/wireplumber/wireplumber.conf.d/bluetooth.conf \
+"

--- a/recipes-multimedia/pipewire/pipewire/pipewire-telephony-dbus.conf
+++ b/recipes-multimedia/pipewire/pipewire/pipewire-telephony-dbus.conf
@@ -1,0 +1,29 @@
+<!-- This configuration file specifies the required security policies
+     for PipeWire native bluez5 backend Telephony service to work on
+     the system bus (needed when wireplumber runs as main-systemwide,
+     i.e. no session bus is available). -->
+
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- wireplumber runs as the pipewire user and registers the service -->
+  <policy user="pipewire">
+    <allow own="org.pipewire.Telephony"/>
+  </policy>
+
+  <policy user="root">
+    <allow send_destination="org.pipewire.Telephony"/>
+  </policy>
+
+  <policy at_console="true">
+    <allow send_destination="org.pipewire.Telephony"/>
+  </policy>
+
+  <!-- Deny call control to everyone else, matching the oFono policy
+       this D-Bus API is modelled on -->
+  <policy context="default">
+    <deny send_destination="org.pipewire.Telephony"/>
+  </policy>
+
+</busconfig>

--- a/recipes-multimedia/pipewire/pipewire_%.bbappend
+++ b/recipes-multimedia/pipewire/pipewire_%.bbappend
@@ -1,12 +1,18 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom-distro = " file://dmaheap.conf"
+SRC_URI:append:qcom-distro = " file://pipewire-telephony-dbus.conf"
 
 do_install:append:qcom-distro() {
     install -d ${D}${systemd_system_unitdir}/pipewire.service.d
     install -m 0644 ${UNPACKDIR}/dmaheap.conf \
         ${D}${systemd_system_unitdir}/pipewire.service.d/dmaheap.conf
+    install -Dm 0644 ${UNPACKDIR}/pipewire-telephony-dbus.conf \
+        ${D}${sysconfdir}/dbus-1/system.d/pipewire-telephony-dbus.conf
 }
+
+FILES:${PN}:append:qcom-distro = " ${sysconfdir}/dbus-1/system.d/pipewire-telephony-dbus.conf"
+CONFFILES:${PN}:append:qcom-distro = " ${sysconfdir}/dbus-1/system.d/pipewire-telephony-dbus.conf"
 
 # Enable pipewire-pulse as a system-wide service
 SYSTEMD_SERVICE:${PN}-pulse:qcom-distro = "pipewire-pulse.service"


### PR DESCRIPTION
  **Summary**

wireplumber.service runs with the systemwide profile (main-systemwide, User=pipewire). It has no session D-Bus of its own.

The bluez5 native backend's Telephony service (org.pipewire.Telephony) defaults to connecting to the session bus. That bus does not exist in this deployment, so the Telephony D-Bus service fails to come up.

Without it, HFP call-control features silently fail: dial/answer/hangup, hold/swap, speaker/mic volume.

  ### Changes

- recipes-multimedia/audio/wireplumber_%.bbappend, recipes-multimedia/audio/files/bluetooth.conf (new)

- Set bluez5.telephony.use-system-bus = true. This makes the Telephony service connect to the system bus instead of the
  nonexistent session bus.
- recipes-multimedia/pipewire/pipewire_%.bbappend, recipes-multimedia/pipewire/pipewire/pipewire-telephony-dbus.conf (new)

- The system bus denies all access by default.  Since the Telephony service is switched to the system bus, this adds an explicit
  D-Bus policy granting the pipewire user permission to own the org.pipewire.Telephony service name.

  **Testing**

Verified on iq-615-evk with the bluez5 native HFP backend

- org.pipewire.Telephony.AudioGateway1 is visible on the system bus.
- Placed a real HFP call over Bluetooth. Verified SCO audio is actually flowing (HCI sco packet counters incrementing).
- Verified SpeakerVolume/MicrophoneVolume properties on AudioGateway1 take effect.
- Verified hangup and re-dial work correctly.

CRs-Fixed: 4611483