### PR TITLE
recipes-connectivity: wpa-supplicant: Enable suiteb, wnm and mbo

### DIFF
--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG:append:qcom-distro = " suiteb wnm mbo"


### PR DESCRIPTION
Enable the suiteb, wnm and mbo PACKAGECONFIG options for qcom-distro builds to support WPA Suite B, Wireless Network Management and Multi Band Operation features.

- suiteb: enable CONFIG_SUITEB and CONFIG_SUITEB192 for WPA-EAP-SUITE-B/WPA-EAP-SUITE-B-192 enterprise modes
- wnm: enable CONFIG_WNM for IEEE 802.11v Wireless Network Management
- mbo: enable CONFIG_MBO for Multi Band Operation extensions used with BSS Transition Management

CRs-Fixed: 4551534, 4562906