### PR TITLE
packagegroup-benchmark: add vkmark and osbench

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-benchmark.bb
@@ -13,6 +13,8 @@ RDEPENDS:${PN} = "\
     mbw \
     memtester \
     netperf \
+    osbench \
     phoronix-test-suite \
     sysbench \
+    vkmark \
     "


### PR DESCRIPTION
Include vkmark and osbench in the benchmark package group to expand GPU and operating system subsystem testing capabilities for the meta-qcom-distro distribution.