### PR TITLE
recipes-quickboot: Add QuickBoot early boot optimization recipes

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -19,6 +19,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     kgsl-dlkm \
     libdiag-bin \
     onnxruntime-qnn \
+    packagegroup-qcom-quickboot \
     qcom-adreno \
     qcom-sensors-binaries \
     qwes \

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -5,5 +5,6 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     quickboot-audio \
+    quickboot-camera \
     quickboot-display \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Qualcomm Quickboot packagegroup"
+DESCRIPTION = "Package group to bring in quickboot packages"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = "\
+    quickboot-display \
+    "

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -4,5 +4,6 @@ DESCRIPTION = "Package group to bring in quickboot packages"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
+    quickboot-audio \
     quickboot-display \
     "

--- a/recipes-quickboot/quickboot-audio/files/audio-modules-common.conf
+++ b/recipes-quickboot/quickboot-audio/files/audio-modules-common.conf
@@ -1,0 +1,13 @@
+# Common audio kernel modules — loaded on all supported machines.
+# These are Qualcomm platform infrastructure modules present on all
+# modern Qualcomm SoCs using the Q6 DSP audio subsystem.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is common for all machines
+
+qrtr-smd
+rpmsg_ctrl
+qcom_q6v5_pas
+fastrpc
+q6apm-dai
+q6apm-lpass-dais

--- a/recipes-quickboot/quickboot-audio/files/audio-modules.conf
+++ b/recipes-quickboot/quickboot-audio/files/audio-modules.conf
@@ -1,0 +1,19 @@
+# Accelerate audio bring-up by preloading all audio related modules during boot
+# using systemd-modules-load.service.
+
+# This below modules list avoids the usual latency in the udev coldplug flow and
+# makes /dev/soundcontrolC0 available sooner.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is common for all machines
+
+qrtr-smd
+rpmsg_ctrl
+qcom_q6v5_pas
+fastrpc
+snd-soc-dmic
+snd-soc-max98357a
+snd-soc-hdmi-codec
+q6apm-dai
+q6apm-lpass-dais
+snd-soc-sc8280xp

--- a/recipes-quickboot/quickboot-audio/files/iq-9075-evk/audio-modules.conf
+++ b/recipes-quickboot/quickboot-audio/files/iq-9075-evk/audio-modules.conf
@@ -1,0 +1,10 @@
+# Target-specific audio modules for iq-9075-evk (SA8775P / SC8280XP).
+# Appended after audio-modules-common.conf on this machine.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is meant for machine : 'iq-9075-evk'
+
+snd-soc-dmic
+snd-soc-hdmi-codec
+snd-soc-sc8280xp
+snd-soc-max98357a

--- a/recipes-quickboot/quickboot-audio/quickboot-audio_1.0.bb
+++ b/recipes-quickboot/quickboot-audio/quickboot-audio_1.0.bb
@@ -1,0 +1,39 @@
+SUMMARY = "Early Audio Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster audio \
+driver probes during boot"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# Install common modules first, then machine-specific ones.
+SRC_URI = "file://audio-modules-common.conf"
+SRC_URI:append:iq-9075-evk = " file://audio-modules.conf"
+
+# audioreach_driver is an out-of-tree kernel module provided by meta-audioreach layer.
+# Install it only when meta-audioreach layer is present.
+AUDIOREACH_MODULE = "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', 'audioreach_driver', '', d)}"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modules-load.d/
+    install -m 0644 ${UNPACKDIR}/audio-modules-common.conf \
+        ${D}${sysconfdir}/modules-load.d/quickboot-audio.conf
+
+    # Append AudioReach out-of-tree module when meta-audioreach layer is present
+    if [ -n "${AUDIOREACH_MODULE}" ]; then
+        echo "${AUDIOREACH_MODULE}" >> \
+            ${D}${sysconfdir}/modules-load.d/quickboot-audio.conf
+    fi
+}
+
+do_install:append:iq-9075-evk() {
+    cat ${UNPACKDIR}/audio-modules.conf \
+        >> ${D}${sysconfdir}/modules-load.d/quickboot-audio.conf
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/quickboot-audio.conf \
+"
+
+RDEPENDS:${PN} = "udev"

--- a/recipes-quickboot/quickboot-audio/quickboot-audio_1.0.bb
+++ b/recipes-quickboot/quickboot-audio/quickboot-audio_1.0.bb
@@ -1,0 +1,44 @@
+SUMMARY = "Early Audio Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster audio \
+driver probes during boot"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://audio-modules.conf \
+"
+
+# audioreach_driver is an out-of-tree kernel module provided exclusively by the
+# meta-audioreach layer (recipes-kernel/audioreach-kernel). It is NOT part of
+# the upstream kernel and will not exist on systems built without meta-audioreach.
+#
+# bb.utils.contains() checks at parse time whether 'meta-audioreach' appears in
+# BBFILE_COLLECTIONS (the space-separated list of all active layer names).
+#
+#   - If meta-audioreach IS present  → AUDIOREACH_MODULE = "audioreach_driver"
+#   - If meta-audioreach is NOT present → AUDIOREACH_MODULE = "" (empty)
+AUDIOREACH_MODULE = "${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', 'audioreach_driver', '', d)}"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modules-load.d/
+    install -m 0644 ${UNPACKDIR}/audio-modules.conf \
+        ${D}${sysconfdir}/modules-load.d/quickboot-audio.conf
+
+    # audioreach_driver is an out-of-tree module from meta-audioreach.
+    # AUDIOREACH_MODULE is set to 'audioreach_driver' at parse time if
+    # meta-audioreach is in BBFILE_COLLECTIONS, otherwise it is empty.
+    # This appends it to the module load list only when the layer is present.
+    if [ -n "${AUDIOREACH_MODULE}" ]; then
+        echo "${AUDIOREACH_MODULE}" >> \
+            ${D}${sysconfdir}/modules-load.d/quickboot-audio.conf
+    fi
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/quickboot-audio.conf \
+"
+
+RDEPENDS:${PN} = "udev"

--- a/recipes-quickboot/quickboot-camera/files/camera-modules-common.conf
+++ b/recipes-quickboot/quickboot-camera/files/camera-modules-common.conf
@@ -1,0 +1,13 @@
+# Common camera kernel modules — loaded on all supported machines.
+# These are upstream V4L2 framework modules, the Qualcomm Iris VPU driver,
+# and the core MSM DRM driver present on all Qualcomm MSM platforms.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is common for all machines
+
+videobuf2_common
+videobuf2_v4l2
+v4l2_mem2mem
+llcc_qcom
+iris_vpu
+gpio_shared_proxy

--- a/recipes-quickboot/quickboot-camera/files/camera-modules.conf
+++ b/recipes-quickboot/quickboot-camera/files/camera-modules.conf
@@ -1,0 +1,10 @@
+# Common camera kernel modules — loaded on all supported machines.
+#
+# This file is intentionally empty for now. 
+#
+# As QuickBoot camera support is validated on additional machines, modules
+# that are confirmed common across all targets can be added here.
+#
+# This file must exist so that the recipe builds successfully on all machines.
+# Machine-specific modules live in files/<machine>/camera-modules.conf and
+# take precedence over this file.

--- a/recipes-quickboot/quickboot-camera/files/iq-9075-evk/camera-modules.conf
+++ b/recipes-quickboot/quickboot-camera/files/iq-9075-evk/camera-modules.conf
@@ -1,0 +1,12 @@
+# Machine-specific camera modules for iq-9075-evk.
+# Appended after camera-modules-common.conf on this machine.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is meant for machine : 'iq-9075-evk'
+
+# List of drivers to be installed :
+# SA8775P camera clock controller
+# QCS9100 / IQ9075 Spectra camera driver
+
+camcc_sa8775p
+camera_qcs9100

--- a/recipes-quickboot/quickboot-camera/files/iq-9075-evk/camera-modules.conf
+++ b/recipes-quickboot/quickboot-camera/files/iq-9075-evk/camera-modules.conf
@@ -1,0 +1,17 @@
+# Accelerate camera bring-up by preloading all camera related modules during boot
+# using systemd-modules-load.service.
+
+# This below modules list avoids the usual latency in the udev coldplug flow and
+# makes /dev/video0 available sooner.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is meant for machine : 'iq-9075-evk'
+
+llcc_qcom
+camcc_sa8775p
+camera_qcs9100
+videobuf2_common
+videobuf2_v4l2
+v4l2_mem2mem
+iris_vpu
+msm

--- a/recipes-quickboot/quickboot-camera/quickboot-camera_1.0.bb
+++ b/recipes-quickboot/quickboot-camera/quickboot-camera_1.0.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Early Camera Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster camera \
+driver probes during boot"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# Install common modules first, then machine-specific ones.
+SRC_URI = "file://camera-modules-common.conf"
+SRC_URI:append:iq-9075-evk = " file://camera-modules.conf"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modules-load.d/
+    install -m 0644 ${UNPACKDIR}/camera-modules-common.conf \
+        ${D}${sysconfdir}/modules-load.d/quickboot-camera.conf
+}
+
+do_install:append:iq-9075-evk() {
+    cat ${UNPACKDIR}/camera-modules.conf \
+        >> ${D}${sysconfdir}/modules-load.d/quickboot-camera.conf
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/quickboot-camera.conf \
+"
+
+RDEPENDS:${PN} = "udev"

--- a/recipes-quickboot/quickboot-camera/quickboot-camera_1.0.bb
+++ b/recipes-quickboot/quickboot-camera/quickboot-camera_1.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Early Camera Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster camera \
+driver probes during boot"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://camera-modules.conf \
+"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    # Install kernel module load list for camera pipeline
+    install -d ${D}${sysconfdir}/modules-load.d/
+    install -m 0644 ${UNPACKDIR}/camera-modules.conf \
+        ${D}${sysconfdir}/modules-load.d/quickboot-camera.conf
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/quickboot-camera.conf \
+"
+
+RDEPENDS:${PN} = "udev"

--- a/recipes-quickboot/quickboot-display/files/display-modules-common.conf
+++ b/recipes-quickboot/quickboot-display/files/display-modules-common.conf
@@ -1,0 +1,14 @@
+# Common display kernel modules — loaded on all supported machines.
+# These are generic DRM/display stack modules present on all Qualcomm MSM platforms.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is common for all machines
+
+# List of drivers to be installed :
+# Core Qualcomm MSM DRM driver
+# Generic DRM display connector helper (upstream drivers/gpu/drm/)
+# Generic USB Type-C subsystem (upstream drivers/usb/typec/)
+
+msm
+display_connector
+typec

--- a/recipes-quickboot/quickboot-display/files/display-modules.conf
+++ b/recipes-quickboot/quickboot-display/files/display-modules.conf
@@ -1,0 +1,10 @@
+# Common display kernel modules — loaded on all supported machines.
+#
+# This file is intentionally empty for now. i
+#
+# As QuickBoot display support is validated on additional machines, modules
+# that are confirmed common across all targets can be added here.
+#
+# This file must exist so that the recipe builds successfully on all machines.
+# Machine-specific modules live in files/<machine>/display-modules.conf and
+# take precedence over this file.

--- a/recipes-quickboot/quickboot-display/files/iq-9075-evk/display-modules.conf
+++ b/recipes-quickboot/quickboot-display/files/iq-9075-evk/display-modules.conf
@@ -1,0 +1,14 @@
+# Machine-specific display modules for iq-9075-evk.
+# Appended after display-modules-common.conf on this machine.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is meant for machine : 'iq-9075-evk'
+
+# List of drivers to be installed 
+# SA8775P GPU clock controller
+# SA8775P display clock controller
+# eDP PHY driver
+
+gpucc_sa8775p
+dispcc0_sa8775p
+phy_qcom_edp

--- a/recipes-quickboot/quickboot-display/files/iq-9075-evk/display-modules.conf
+++ b/recipes-quickboot/quickboot-display/files/iq-9075-evk/display-modules.conf
@@ -1,0 +1,14 @@
+# Accelerate display bring-up by preloading all display related modules during boot
+# using systemd-modules-load.service.
+
+# Below modules are loaded early to avoid the usual latency in the udev coldplug
+# flow and makes display card0 available sooner.
+
+# This configuration file is placed in '/etc/modules-load.d/'
+# This file is meant for machine : 'iq-9075-evk'
+
+display_connector
+gpucc_sa8775p
+dispcc0_sa8775p
+msm
+typec

--- a/recipes-quickboot/quickboot-display/quickboot-display_1.0.bb
+++ b/recipes-quickboot/quickboot-display/quickboot-display_1.0.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Early Display Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster \
+display driver probes during boot"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# Install common modules first, then machine-specific ones.
+SRC_URI = "file://display-modules-common.conf"
+SRC_URI:append:iq-9075-evk = " file://display-modules.conf"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modules-load.d/
+    install -m 0644 ${UNPACKDIR}/display-modules-common.conf \
+        ${D}${sysconfdir}/modules-load.d/quickboot-display.conf
+}
+
+do_install:append:iq-9075-evk() {
+    cat ${UNPACKDIR}/display-modules.conf \
+        >> ${D}${sysconfdir}/modules-load.d/quickboot-display.conf
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/quickboot-display.conf \
+"
+
+RDEPENDS:${PN} = "udev"

--- a/recipes-quickboot/quickboot-display/quickboot-display_1.0.bb
+++ b/recipes-quickboot/quickboot-display/quickboot-display_1.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Early Display Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster \
+display driver probes during boot"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://display-modules.conf \
+"
+
+S = "${UNPACKDIR}"
+
+do_install() {
+    # Install kernel module load list for early display pipeline
+    install -d ${D}${sysconfdir}/modules-load.d/
+    install -m 0644 ${UNPACKDIR}/display-modules.conf \
+        ${D}${sysconfdir}/modules-load.d/quickboot-display.conf
+}
+
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/quickboot-display.conf \
+"
+
+RDEPENDS:${PN} = "udev"


### PR DESCRIPTION
Add recipes to pre-load kernel modules and install udev rules for the display, audio, and camera subsystems early in the boot sequence. This eliminates probe deferrals (-EPROBE_DEFER) and reduces time-to-first-frame and time-to-first-sound by bypassing the on-demand udev coldplug module loading route.

All recipes are gated on DISTRO_FEATURES (quickboot, quickboot-display, quickboot-audio, quickboot-camera) and are only built and installed when the corresponding features are explicitly enabled.

Note: Verified on IQ-9075-EVK ( QLI-2.0 Build tag: wrynose-260725.1 )

This QuickBoot phase-1 optimization reduces driver initialization times:
	Display: 4.6s → 2.7s, Camera: 4.1s → 2.8s, Audio: 9.6s → 7.5s.

Default timestamps
[    4.616166] [drm] Initialized msm 1.13.0 for
ae01000.display-controller on minor 0
[    4.142160] CAM_INFO: CAM-UTIL: cam_main_probe: 336: Spectra camera
driver initialized rc : 0
[    9.641476] iq-9075-evk wireplumber[844]: device-detection:
jack.connected is nil, skipping pw-play

With Optimization timestamps
[    2.725317] [drm] Initialized msm 1.13.0 for
ae01000.display-controller on minor 0
[    2.837135] CAM_INFO: CAM-UTIL: cam_main_probe: 336: Spectra camera
driver initialized rc : 0
[    7.568301] iq-9075-evk wireplumber[862]: device-detection:
jack.connected is nil, skipping pw-play