### PR TITLE
recipes-connectivity: wpa-supplicant: Enable suiteb, wnm and mbo

### DIFF
--- a/recipes-backports/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/recipes-backports/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,8 @@
+python __anonymous() {
+    if "qcom-distro" in d.getVar("DISTROOVERRIDES").split(":"):
+        d.setVarFlag("PACKAGECONFIG", "suiteb", ",,")
+        d.setVarFlag("PACKAGECONFIG", "wnm", ",,")
+        d.setVarFlag("PACKAGECONFIG", "mbo", ",,")
+}
+
+PACKAGECONFIG:append:qcom-distro = " suiteb wnm mbo"

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,14 @@
+do_configure:append:qcom-distro() {
+    if ${@ bb.utils.contains('PACKAGECONFIG', 'suiteb', 'true', 'false', d) }; then
+        echo 'CONFIG_SUITEB=y'   >> wpa_supplicant/.config
+        echo 'CONFIG_SUITEB192=y' >> wpa_supplicant/.config
+    fi
+
+    if ${@ bb.utils.contains('PACKAGECONFIG', 'wnm', 'true', 'false', d) }; then
+        echo 'CONFIG_WNM=y' >> wpa_supplicant/.config
+    fi
+
+    if ${@ bb.utils.contains('PACKAGECONFIG', 'mbo', 'true', 'false', d) }; then
+        echo 'CONFIG_MBO=y' >> wpa_supplicant/.config
+    fi
+}


### PR DESCRIPTION
Enable the suiteb, wnm and mbo PACKAGECONFIG options for qcom-distro builds to support WPA Suite B, Wireless Network Management and Multi Band Operation features.

- suiteb: enable CONFIG_SUITEB and CONFIG_SUITEB192 for WPA-EAP-SUITE-B/WPA-EAP-SUITE-B-192 enterprise modes
- wnm: enable CONFIG_WNM for IEEE 802.11v Wireless Network Management
- mbo: enable CONFIG_MBO for Multi Band Operation extensions used with BSS Transition Management

CRs-Fixed: 4551534, 4562906