### PR TITLE
packagegroup-qcom-test-pkgs: add sox and mediainfo

### DIFF
--- a/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-test-pkgs.bb
@@ -21,6 +21,7 @@ RDEPENDS:${PN} = "\
     pulseaudio-misc \
     rng-tools \
     sigma-dut \
+    sox \
     util-linux \
     v4l-utils \
     yavta \


### PR DESCRIPTION
Adds sox and mediainfo to the test packagegroup so these tools are
available on-device for audio content validation in AudioRecord
test cases.

These tools help catch issues currently missed by file-size-only
validation:
- sox: waveform analysis (silence, truncation via "Premature EOF" warning)
