### PR TITLE
selinux: Add XDG Downloads mount-on support for dockerd

### DIFF
--- a/recipes-security/refpolicy/refpolicy-targeted/0005-xdg-Add-interface-for-mounting-on-Downloads-director.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/0005-xdg-Add-interface-for-mounting-on-Downloads-director.patch
@@ -1,0 +1,53 @@
+From 783395acf331bca7328eb296bd957538400c5690 Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Fri, 31 Jul 2026 14:47:46 +0300
+Subject: [PATCH 5/6] xdg: Add interface for mounting on Downloads directories
+
+Add the xdg_mounton_downloads() interface to allow a domain to use
+the mounton permission on xdg_downloads_t directories.
+
+This interface grants mounton access to XDG Downloads directories and
+allows searching user home directories, enabling policy modules to
+optionally permit mounting filesystems on a user's Downloads directory.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1191]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/system/xdg.if | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
+
+diff --git a/policy/modules/system/xdg.if b/policy/modules/system/xdg.if
+index 92f2eedf2..64eee78d2 100644
+--- a/policy/modules/system/xdg.if
++++ b/policy/modules/system/xdg.if
+@@ -1206,6 +1206,26 @@ interface(`xdg_relabel_downloads',`
+ 	userdom_search_user_home_dirs($1)
+ ')
+ 
++########################################
++## <summary>
++##	Allow mounting on the xdg downloads directory.
++## </summary>
++## <param name="domain">
++##	<summary>
++##	Domain allowed access.
++##	</summary>
++## </param>
++#
++interface(`xdg_mounton_downloads',`
++	gen_require(`
++		type xdg_downloads_t;
++	')
++
++	allow $1 xdg_downloads_t:dir { search_dir_perms mounton_dir_perms };
++
++	userdom_search_user_home_dirs($1)
++')
++
+ ########################################
+ ## <summary>
+ ##	Watch the xdg pictures home directories
+-- 
+2.43.0
+

--- a/recipes-security/refpolicy/refpolicy-targeted/0006-docker-Add-tunable-for-mounting-on-XDG-Downloads-dir.patch
+++ b/recipes-security/refpolicy/refpolicy-targeted/0006-docker-Add-tunable-for-mounting-on-XDG-Downloads-dir.patch
@@ -1,0 +1,56 @@
+From 0ff4d905617ef8bb7b70084d66d19e290e2158b4 Mon Sep 17 00:00:00 2001
+From: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+Date: Fri, 31 Jul 2026 14:49:39 +0300
+Subject: [PATCH 6/6] docker: Add tunable for mounting on XDG Downloads
+ directories
+
+Add the dockerd_mounton_xdg_downloads tunable to optionally
+allow the Docker daemon to mount filesystems on user XDG Downloads
+directories.
+
+When enabled, the tunable grants dockerd_t the mounton permission on
+xdg_downloads_t through the xdg_mounton_downloads() interface.
+The tunable is disabled by default.
+
+Upstream-Status: Backport [https://github.com/SELinuxProject/refpolicy/pull/1191]
+
+Signed-off-by: Kemal Rasim Sh <kshakir@qti.qualcomm.com>
+---
+ policy/modules/services/docker.te | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/policy/modules/services/docker.te b/policy/modules/services/docker.te
+index cf45fc188..eb408a30f 100644
+--- a/policy/modules/services/docker.te
++++ b/policy/modules/services/docker.te
+@@ -14,6 +14,14 @@ policy_module(docker)
+ ## </desc>
+ gen_tunable(dockerd_connect_user_services, false)
+ 
++## <desc>
++##	<p>
++##	Determine whether the Docker daemon can mount filesystems
++##	on user XDG Downloads directories.
++##	</p>
++## </desc>
++gen_tunable(dockerd_mounton_xdg_downloads, false)
++
+ container_engine_domain_template(dockerd)
+ container_system_engine(dockerd_t)
+ optional_policy(`
+@@ -98,6 +106,12 @@ optional_policy(`
+ 	')
+ ')
+ 
++optional_policy(`
++	tunable_policy(`dockerd_mounton_xdg_downloads',`
++		xdg_mounton_downloads(dockerd_t)
++	')
++')
++
+ ########################################
+ #
+ # Docker CLI local policy
+-- 
+2.43.0
+

--- a/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
+++ b/recipes-security/refpolicy/refpolicy-targeted_git.bbappend
@@ -4,4 +4,6 @@ SRC_URI:append:qcom-distro = " \
     file://0002-wayland-Add-wayland_stream_connect-interface.patch \
     file://0003-wayland-Label-sockets-under-run-with-wayland_runtime.patch \
     file://0004-docker-Add-tunable-gated-optional-policy-for-dockerd.patch \
+    file://0005-xdg-Add-interface-for-mounting-on-Downloads-director.patch \
+    file://0006-docker-Add-tunable-for-mounting-on-XDG-Downloads-dir.patch \
 "


### PR DESCRIPTION
Add two refpolicy backport patches required to support mounting on user XDG Downloads directories.

* Add xdg_mounton_downloads() interface to grant mounton access on xdg_downloads_t directories.
* Add dockerd_mounton_xdg_downloads tunable to optionally allow dockerd_t to mount filesystems on XDG Downloads directories.
* Keep the tunable disabled by default.

This enables policy-controlled support for container workloads that need bind mounts or filesystem mounts under a user's Downloads directory.

This change was implemented following the guidance and conclusions from the upstream discussion in Issue [#1182 ](https://github.com/SELinuxProject/refpolicy/issues/1182)regarding SELinux labeling and Docker access to specific `$HOME` subdirectories.
