### PR TITLE
qcom-xfce-demo-image: drop IMAGE_BASENAME export

### DIFF
--- a/recipes-products/images/qcom-xfce-demo-image.bb
+++ b/recipes-products/images/qcom-xfce-demo-image.bb
@@ -5,8 +5,6 @@ LICENSE = "MIT"
 DESCRIPTION = "An XFCE demo image for Qualcomm machines"
 SUMMARY = "An XFCE demo image."
 
-export IMAGE_BASENAME = "Qualcomm-XFCE-demo-image"
-
 IMAGE_FEATURES += "x11"
 REQUIRED_DISTRO_FEATURES += "x11 opengl"
 


### PR DESCRIPTION
This is not necessary and only has cosmetic effects, capitalizing some letters.