### PR TITLE
qcom-udev-coldplug-split: add udev trigger deferral

### DIFF
--- a/recipes-support/qcom-udev-trigger/files/qcom-udev-trigger-nonblock.service
+++ b/recipes-support/qcom-udev-trigger/files/qcom-udev-trigger-nonblock.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Deferred udev coldplug for non-block devices
+Documentation=man:udevadm(8)
+DefaultDependencies=no
+After=basic.target
+Before=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+ExecStart=-udevadm trigger --type=all --action=add --subsystem-nomatch=block
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-support/qcom-udev-trigger/files/systemd-udev-trigger-block-only.conf
+++ b/recipes-support/qcom-udev-trigger/files/systemd-udev-trigger-block-only.conf
@@ -1,0 +1,6 @@
+[Service]
+# Keep the sysinit coldplug pass focused on block devices, which are needed for
+# rootfs and local filesystem activation. Non-block devices are coldplugged by
+# qcom-udev-trigger-nonblock.service after basic.target.
+ExecStart=
+ExecStart=-udevadm trigger --type=all --action=add --subsystem-match=block

--- a/recipes-support/qcom-udev-trigger/qcom-udev-trigger_1.0.bb
+++ b/recipes-support/qcom-udev-trigger/qcom-udev-trigger_1.0.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Split udev coldplug into early block and deferred non-block passes"
+DESCRIPTION = "Installs a systemd-udev-trigger.service drop-in that triggers \
+block devices during sysinit, plus a deferred service that coldplugs non-block \
+devices after basic.target."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://systemd-udev-trigger-block-only.conf \
+    file://qcom-udev-trigger-nonblock.service \
+"
+
+inherit allarch features_check systemd
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+S = "${UNPACKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "qcom-udev-trigger-nonblock.service"
+
+do_compile[noexec] = "1"
+
+do_install() {
+    install -Dm 0644 ${UNPACKDIR}/systemd-udev-trigger-block-only.conf \
+        ${D}${systemd_system_unitdir}/systemd-udev-trigger.service.d/block-only.conf
+    install -Dm 0644 ${UNPACKDIR}/qcom-udev-trigger-nonblock.service \
+        ${D}${systemd_system_unitdir}/qcom-udev-trigger-nonblock.service
+}
+
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/systemd-udev-trigger.service.d/block-only.conf \
+"


### PR DESCRIPTION
Prioritize block-device coldplug before sysinit.target to reduce udev queue contention on the system initialization critical path. Defer non-block device coldplug until after basic.target, while preserving the standard coldplug behavior for the remainder of boot.