### PR TITLE
crash: Fix cross compilation for 32-bit arm

### DIFF
--- a/recipes-kernel/crash/crash/0001-Makefile-support-cross-compiling-for-32-bit-arm.patch
+++ b/recipes-kernel/crash/crash/0001-Makefile-support-cross-compiling-for-32-bit-arm.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 30 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Makefile: support cross compiling for 32-bit arm
+
+The CONF_TARGET_ARCH cross-compilation mapping enumerates aarch64,
+s390x, powerpc64, ppc64le, alpha, i386, mips, sparc64 and riscv64 but
+omits 32-bit arm. As a result, building with CROSS_COMPILE=arm-* (e.g.
+arm-poky-linux-gnueabi-) aborts at Makefile parse time with:
+
+    Makefile:75: *** The current Arch(arm) does not support cross compilation.  Stop.
+
+ARM is already a valid crash target (defs.h/configure.c), so map the
+normalized "arm" arch to CONF_TARGET_ARCH=ARM like every other arch.
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ Makefile | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/Makefile b/Makefile
+index 1111111..2222222 100644
+--- a/Makefile
++++ b/Makefile
+@@ -55,6 +55,8 @@ ifeq (${ARCH}, x86_64)
+ CONF_TARGET_ARCH := X86_64
+ else ifeq (${ARCH}, aarch64)
+ CONF_TARGET_ARCH := ARM64
++else ifeq (${ARCH}, arm)
++CONF_TARGET_ARCH := ARM
+ else ifeq (${ARCH}, s390x)
+ CONF_TARGET_ARCH := S390X
+ else ifeq (${ARCH}, powerpc64)
+--
+2.43.0

--- a/recipes-kernel/crash/crash_9.0.2.bbappend
+++ b/recipes-kernel/crash/crash_9.0.2.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " \
+	file://0001-Makefile-support-cross-compiling-for-32-bit-arm.patch \
+"


### PR DESCRIPTION
The upstream crash Makefile CONF_TARGET_ARCH mapping (used when CROSS_COMPILE is set) enumerates most of OE supported arches but omits 32-bit arm. Building with CROSS_COMPILE=arm-* therefore aborts at Makefile parse time:

    Makefile:75: *** The current Arch(arm) does not support cross compilation.  Stop.

ARM is already a valid crash target (defs.h/configure.c), so add a patch mapping the normalized "arm" arch to CONF_TARGET_ARCH=ARM like every other supported arch.

Verified by cross building crash for qemuarm (arm-yoe-linux-gnueabi-):

Backport from meta-oe 63a529202