### PR TITLE
pipewire: add dmaheap sysusers.d entry for OTA safety

### DIFF
--- a/recipes-core/systemd/systemd/dmaheap-sysusers.conf
+++ b/recipes-core/systemd/systemd/dmaheap-sysusers.conf
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Create the dmaheap group required for DMA-HEAP access.
+# Using sysusers.d ensures the group is created declaratively
+# on every boot, making it OTA-safe.
+g dmaheap - - -

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro = " file://dmaheap-sysusers.conf"
+
+do_install:append:qcom-distro() {
+    install -d ${D}${libdir}/sysusers.d
+    install -m 0644 ${UNPACKDIR}/dmaheap-sysusers.conf \
+        ${D}${libdir}/sysusers.d/dmaheap.conf
+}
+
+FILES:${PN}:append:qcom-distro = " ${libdir}/sysusers.d/dmaheap.conf"


### PR DESCRIPTION
The dmaheap group is required by pipewire.service.d/dmaheap.conf (SupplementaryGroups=dmaheap). Previously it was only created via GROUPADD_PARAM at image build time which does not survive OSTree OTA updates. Add a sysusers.d entry alongside the existing dmaheap drop-in so systemd-sysusers creates the group declaratively on every boot from /usr, making it OTA-safe.

Fixes: wpctl status returning Could not connect to PipeWire post OTA (1.9 to 2.0) on QCS9075 RB3 Config-2.

CR-Id: 4591795