### PR TITLE
qcom-multimedia-image: add IMSDK App Builder SDK packages

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -41,7 +41,7 @@ CORE_IMAGE_BASE_INSTALL += " \
 "
 
 # IMSDK currently only used and tested on ARMv8 (aarch64) machines.
-CORE_IMAGE_BASE_INSTALL:append:aarch64 = " gst-plugins-imsdk-oss gst-plugins-imsdk-python"
+CORE_IMAGE_BASE_INSTALL:append:aarch64 = " gst-plugins-imsdk-oss gst-plugins-imsdk-python imsdk-app-builder-cpp imsdk-app-builder-python"
 
 # let's make sure we have a good image.
 REQUIRED_DISTRO_FEATURES += "wayland"


### PR DESCRIPTION
Add IMSDK App Builder C++ and Python SDK packages to the default qcom-multimedia-image installation for aarch64 targets.

The newly added packages provide:
 - C++ Pipeline SDK libraries and sample applications
 - Python Pipeline SDK modules and utilities