### PR TITLE
qcom-multimedia-proprietary-image: Add onnxruntime-qnn

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -18,6 +18,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     iris-video-dlkm \
     kgsl-dlkm \
     libdiag-bin \
+    onnxruntime-qnn \
     qcom-adreno \
     qcom-sensors-binaries \
     qwes \


### PR DESCRIPTION
Install Onnxruntime QNN EP in proprietary image. This plugin is used to leverage hw acceleration for onnxruntime inferencing via QAIRT SDK.