### PR TITLE
github: add compile actions from meta-qcom@896dff1109 and swicth to it

### DIFF
--- a/.github/actions/compile/action.yml
+++ b/.github/actions/compile/action.yml
@@ -1,0 +1,163 @@
+name: Run kas for a specific build configuration
+inputs:
+  machine:
+    required: true
+  distro_yaml:
+    required: true
+  distro_name:
+    required: true
+  kernel_yaml:
+    required: true
+  kernel_dirname:
+    required: true
+  cache_dir:
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download kas lockfile
+      uses: actions/download-artifact@v7
+      with:
+        name: kas-lockfile
+        path: ci/
+
+    - name: Download kas-container
+      uses: actions/download-artifact@v7
+      with:
+         name: kas-container
+         path: ${{runner.temp}}
+
+    - name: Setting up kas-container
+      id: kas-container
+      shell: bash
+      run: |
+        KAS_CONTAINER=$RUNNER_TEMP/kas-container
+        echo "kas_container=$KAS_CONTAINER" >> $GITHUB_OUTPUT
+        chmod +x $KAS_CONTAINER
+
+    - name: Setup build variables
+      id: build-vars
+      shell: bash
+      run: |
+        echo "dl_dir=${INPUTS_CACHE_DIR}/downloads" >> $GITHUB_OUTPUT
+        # use a single shared sstate cache folder, cleaned up by mtime
+        echo "sstate_dir=${INPUTS_CACHE_DIR}/sstate-cache" >> $GITHUB_OUTPUT
+        echo "kas_work_dir=${PWD}/../kas" >> $GITHUB_OUTPUT
+        echo "kas_yamls=ci/ci.yml:ci/${INPUTS_MACHINE}.yml${INPUTS_DISTRO_YAML}${INPUTS_KERNEL_YAML}" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_CACHE_DIR: ${{inputs.cache_dir}}
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+        INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
+
+    - name: Dump kas-build yaml
+      shell: bash
+      run: |
+        mkdir $KAS_WORK_DIR
+        $KAS_CONTAINER dump --resolve-env --resolve-local --resolve-refs ${KAS_YAMLS} > kas-build.yml
+      env:
+        KAS_CONTAINER: ${{ steps.kas-container.outputs.kas_container }}
+        KAS_WORK_DIR: ${{ steps.build-vars.outputs.kas_work_dir }}
+        KAS_YAMLS: ${{ steps.build-vars.outputs.kas_yamls }}
+        DL_DIR: ${{ steps.build-vars.outputs.dl_dir }}
+        SSTATE_DIR: ${{ steps.build-vars.outputs.sstate_dir }}
+
+    - name: Kas qcom world build
+      shell: bash
+      run: |
+        $KAS_CONTAINER build ${KAS_YAMLS}:ci/world.yml
+        ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+        rename.ul -va buildstats buildstats-world $KAS_WORK_DIR/build/buildstats*
+        mv $KAS_WORK_DIR/build/buildstats* .
+      env:
+        KAS_CONTAINER: ${{ steps.kas-container.outputs.kas_container }}
+        KAS_WORK_DIR: ${{ steps.build-vars.outputs.kas_work_dir }}
+        KAS_YAMLS: ${{ steps.build-vars.outputs.kas_yamls }}
+        DL_DIR: ${{ steps.build-vars.outputs.dl_dir }}
+        SSTATE_DIR: ${{ steps.build-vars.outputs.sstate_dir }}
+
+    - name: Kas build images
+      shell: bash
+      run: |
+        $KAS_CONTAINER build ${KAS_YAMLS}
+        ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+        mv $KAS_WORK_DIR/build/buildstats* .
+
+        if [ "${INPUTS_MACHINE}" = "qcom-armv8a" ]; then
+          # SDK only with the default kernel and qcom-distro
+          if [ "${INPUTS_KERNEL_YAML}" = "" ] && [ "${INPUTS_DISTRO_YAML}" = ":ci/qcom-distro.yml" ] ; then
+            $KAS_CONTAINER build ${KAS_YAMLS} --task populate_sdk \
+              --target qcom-multimedia-image \
+              --target qcom-multimedia-proprietary-image
+            ci/kas-container-shell-helper.sh ci/yocto-buildstats.sh
+            rename.ul -av buildstats buildstats-sdk $KAS_WORK_DIR/build/buildstats*
+            mv $KAS_WORK_DIR/build/buildstats* .
+          fi
+        fi
+      env:
+        KAS_CONTAINER: ${{ steps.kas-container.outputs.kas_container }}
+        KAS_WORK_DIR: ${{ steps.build-vars.outputs.kas_work_dir }}
+        KAS_YAMLS: ${{ steps.build-vars.outputs.kas_yamls }}
+        DL_DIR: ${{ steps.build-vars.outputs.dl_dir }}
+        SSTATE_DIR: ${{ steps.build-vars.outputs.sstate_dir }}
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_YAML: ${{ inputs.distro_yaml }}
+        INPUTS_KERNEL_YAML: ${{ inputs.kernel_yaml }}
+
+    - uses: actions/upload-artifact@v6
+      with:
+        name: kas-build-${{ inputs.distro_name }}${{ inputs.kernel_dirname }}-${{ inputs.machine }}
+        path: kas-build.yml
+
+    - name: Stage build artifacts for publishing
+      shell: bash
+      run: |
+        # The upload-private-artifact-action runs from a container that
+        # expects file to be relative to our PWD. deploy_dir is outside
+        # that, so we move things around:
+        deploy_dir=../kas/build/tmp/deploy/images/${INPUTS_MACHINE}
+        uploads_dir=./uploads/${INPUTS_DISTRO_NAME}${INPUTS_KERNEL_DIRNAME}/${INPUTS_MACHINE}
+        mkdir -p $uploads_dir
+        # Publish everything that is linked by bitbake at the end of the build (avoid timestamp and duplication)
+        find $deploy_dir/ -maxdepth 1 -type l -exec cp --dereference {} $uploads_dir/ \;
+        # Files without links: *.vfat, *.elf, *.efi, efi.stub, fit *.its, qcom-metadata.dtb and qclinuxfitImage
+        # Copy *.efi, *.efi and *.vfat as they are useful for debugging
+        find $deploy_dir/ -maxdepth 1 -type f \( -name \*.efi -o -name \*.elf -o -name dtb-\*.vfat \) -exec cp {} $uploads_dir/ \;
+        cp buildstats* kas-build.yml $uploads_dir/
+        if [ -d $deploy_dir/../../sdk ]; then
+          cp $deploy_dir/../../sdk/* $uploads_dir/
+        fi
+      env:
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+        INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
+
+    - name: Upload artifacts to S3 bucket
+      uses: qualcomm-linux/upload-private-artifact-action@aws-v4
+      id: upload_s3_artifacts
+      with:
+        path: ./uploads
+        destination: ${{ github.repository_owner }}/${{ github.event.repository.name }}/${{ github.run_id }}-${{ github.run_attempt }}/
+        s3_bucket: qcom-prd-gh-artifacts
+
+    - name: "Print output"
+      shell: bash
+      id: print-output
+      run: |
+        KERNEL_DIRNAME="${INPUTS_KERNEL_DIRNAME}"
+        BUILDNAME="${INPUTS_MACHINE}_${INPUTS_DISTRO_NAME}${KERNEL_DIRNAME}"
+        FILENAME="build-url_${BUILDNAME}"
+        echo "${UPLOAD_URL}" > "${FILENAME}"
+        echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
+      env:
+        INPUTS_KERNEL_DIRNAME: ${{ inputs.kernel_dirname }}
+        INPUTS_MACHINE: ${{ inputs.machine }}
+        INPUTS_DISTRO_NAME: ${{ inputs.distro_name }}
+        UPLOAD_URL: ${{ steps.upload_s3_artifacts.outputs.url }}
+    - name: Upload build URL
+      uses: actions/upload-artifact@v6
+      with:
+        overwrite: true
+        name: ${{ steps.print-output.outputs.filename }}
+        path: ${{ steps.print-output.outputs.filename }}
+

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -114,7 +114,7 @@ jobs:
           persist-credentials: false
 
       - name: Run kas build
-        uses: qualcomm-linux/meta-qcom/.github/actions/compile@master
+        uses: ./.github/actions/compile
         with:
           machine: ${{matrix.machine}}
           distro_yaml: ${{matrix.distro.yamlfile}}
@@ -241,7 +241,7 @@ jobs:
 
       - name: Run kas build
         if: inputs.profile != 'pr' || (matrix.distro.name != 'debug' && matrix.distro.name != 'performance')
-        uses: qualcomm-linux/meta-qcom/.github/actions/compile@master
+        uses: ./.github/actions/compile
         id: compile_kas
         with:
           machine: ${{matrix.machine}}


### PR DESCRIPTION
The compile/action is no more in use in meta-qcom because it is using a re-usable workflow. The only reason for its existence on meta-qcom is because it's used elsewhere. Therefore, it will be hosted here.