### PR TITLE
[Backport Wrynose] Revert "qcom-networking-image: drop dpdk from the image"

### DIFF
--- a/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
+++ b/dynamic-layers/dpdk/recipes-products/images/qcom-networking-image.bbappend
@@ -1,0 +1,1 @@
+CORE_IMAGE_BASE_INSTALL += "dpdk"


### PR DESCRIPTION
Upstream DPDK now supports compiling shared libraries. This reduces the disk space requirement for compiling DPDK which should fix the CI errors encountered while building DPDK.


(cherry picked from commit f6e3424090f02f1a0ed81148a1cd30aeafc85c82)