### PR TITLE
qcom-multimedia-image: allow the qtiseclib licence on the rb3gen2 TF-A

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -30,6 +30,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-shikra:LICENSE.qcom-2 \
     firmware-qcom-boot-sm8750:LICENSE.qcom-2 \
     trusted-firmware-a-qcom:LICENSE.qcom \
+    trusted-firmware-a-qcom-rb3gen2:LICENSE.qcom \
 "
 
 # QA check considers packages in INCOMPATIBLE_LICENSE_EXCEPTIONS list still to


### PR DESCRIPTION
qualcomm-linux/meta-qcom#2910 splits `trusted-firmware-a-qcom` per device, so the recipe carrying the qtiseclib blob becomes `trusted-firmware-a-qcom-rb3gen2` and stops matching the exception. The image licence gate then fails on rb3gen2-core-kit-open-fw.

Add the new name; the old one stays until the split lands.

Needed before meta-qcom#2910 can go green. CI there tracks this repo at `main` with no pin, so merging is enough.