### PR TITLE
ci/qcom-distro.yml: patch meta-selinux to fix nativesdk-rpm builds

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -35,6 +35,13 @@ repos:
 
   meta-selinux:
     url: https://git.yoctoproject.org/meta-selinux
+    patches:
+      libsepol-nativesdk:
+        repo: meta-qcom-distro
+        path: patches/selinux/0001-libsepol-enable-nativesdk.patch
+      libselinux-nativesdk:
+        repo: meta-qcom-distro
+        path: patches/selinux/0002-libselinux-enable-nativesdk.patch
 
   meta-updater:
     url: https://github.com/uptane/meta-updater

--- a/patches/selinux/0001-libsepol-enable-nativesdk.patch
+++ b/patches/selinux/0001-libsepol-enable-nativesdk.patch
@@ -1,0 +1,27 @@
+From acc225f1ed99213a4e3a6f6c0384498a8122d428 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 3 Aug 2026 23:50:21 +0300
+Subject: [meta-selinux][PATCH 1/2] libsepol: enable nativesdk
+
+Enable nativesdk class extension, letting libsepol to satisfy
+dependencies of nativesdk-rpm if SELinux is enabled by the distro.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/yocto-patches/20260804114749.625810-1-dmitry.baryshkov@oss.qualcomm.com/T/#t]
+---
+ recipes-security/selinux/libsepol_3.10.bb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/recipes-security/selinux/libsepol_3.10.bb b/recipes-security/selinux/libsepol_3.10.bb
+index 0a51aba28ee8..49cc9d256460 100644
+--- a/recipes-security/selinux/libsepol_3.10.bb
++++ b/recipes-security/selinux/libsepol_3.10.bb
+@@ -17,4 +17,4 @@ DEPENDS = "flex-native"
+ # sections which are not affected by -ffile-prefix-map, causing buildpaths QA failure
+ LTO = ""
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
+-- 
+2.47.3
+

--- a/patches/selinux/0002-libselinux-enable-nativesdk.patch
+++ b/patches/selinux/0002-libselinux-enable-nativesdk.patch
@@ -1,0 +1,33 @@
+From 97b3072a20f21b0ec523e788d318b912c2153fa2 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Date: Mon, 3 Aug 2026 23:50:21 +0300
+Subject: [meta-selinux][PATCH 2/2] libselinux: enable nativesdk
+
+Enable nativesdk class extension, letting libselinux to satisfy
+dependencies of nativesdk-rpm if SELinux is enabled by the distro. The
+binaries are not necessary for the SDK, so they are explicitly dropped.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lore.kernel.org/yocto-patches/20260804114749.625810-2-dmitry.baryshkov@oss.qualcomm.com/]
+---
+ recipes-security/selinux/libselinux_3.10.bb | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/recipes-security/selinux/libselinux_3.10.bb b/recipes-security/selinux/libselinux_3.10.bb
+index 86c9168a002d..94f3fcdf861d 100644
+--- a/recipes-security/selinux/libselinux_3.10.bb
++++ b/recipes-security/selinux/libselinux_3.10.bb
+@@ -32,4 +32,9 @@ EXTRA_OEMAKE:append:libc-musl = " FTS_LDLIBS=-lfts"
+ # sections which are not affected by -ffile-prefix-map, causing buildpaths QA failure
+ LTO = ""
+ 
+-BBCLASSEXTEND = "native"
++BBCLASSEXTEND = "native nativesdk"
++
++do_install:append:class-nativesdk() {
++    # /sbin is hardcoded in the Makefile
++    rm -r ${D}${prefix}/sbin
++}
+-- 
+2.47.3
+


### PR DESCRIPTION
The oe-core revision pinned via meta-qcom's ci/base.lock.yml makes nativesdk-rpm depend on nativesdk-libselinux when selinux is in DISTRO_FEATURES, which meta-selinux does not provide, breaking all qcom-distro-catchall builds:

  ERROR: Nothing PROVIDES 'nativesdk-libselinux' (but
  virtual:nativesdk:.../rpm_4.20.1.bb DEPENDS on or otherwise requires it)

meta-qcom already carries the fix (commit 4229f22dbe7d "ci: bump OE-Core to include licence changes") through two meta-selinux patches that enable the nativesdk class extension for libsepol and libselinux. Those patches are applied from meta-qcom's own ci/qcom-distro.yml, which this repository does not include -- the CI compositions here use the local ci/qcom-distro.yml instead -- so they were never applied to our builds.

Import the same patches (already submitted upstream to meta-selinux) and apply them from the local distro config. They can be dropped once they land upstream and the meta-selinux revision is bumped past them.

Fixes: https://github.com/qualcomm-linux/meta-qcom-distro/issues/423