### PR TITLE
weston-init: add sysusers.d/tmpfiles.d entries for OTA safety

### DIFF
--- a/recipes-graphics/wayland/weston-init.bbappend
+++ b/recipes-graphics/wayland/weston-init.bbappend
@@ -5,6 +5,8 @@ SRC_URI:append:qcom-distro = " \
     file://qcom-background.ini \
     file://qcom-background.png \
     file://weston-groups.conf \
+    file://weston-sysusers.conf \
+    file://weston-tmpfiles.conf \
 "
 
 do_install:append:qcom-distro() {
@@ -16,9 +18,19 @@ do_install:append:qcom-distro() {
     install -d ${D}${systemd_system_unitdir}/weston.service.d
     install -m 0644 ${S}/weston-groups.conf \
         ${D}${systemd_system_unitdir}/weston.service.d/weston-groups.conf
+
+    install -d ${D}${nonarch_libdir}/sysusers.d
+    install -m 0644 ${S}/weston-sysusers.conf \
+        ${D}${nonarch_libdir}/sysusers.d/weston.conf
+
+    install -d ${D}${nonarch_libdir}/tmpfiles.d
+    install -m 0644 ${S}/weston-tmpfiles.conf \
+        ${D}${nonarch_libdir}/tmpfiles.d/weston.conf
 }
 
 FILES:${PN}:append:qcom-distro = " \
     ${datadir}/backgrounds/qcom-background.png \
     ${systemd_unitdir}/system/weston.service.d/weston-groups.conf \
+    ${nonarch_libdir}/sysusers.d/weston.conf \
+    ${nonarch_libdir}/tmpfiles.d/weston.conf \
 "

--- a/recipes-graphics/wayland/weston-init/weston-sysusers.conf
+++ b/recipes-graphics/wayland/weston-init/weston-sysusers.conf
@@ -1,0 +1,15 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Create the wayland, seat and weston groups, and add the
+# weston user to the group memberships it needs, required for
+# weston.socket/weston.service to start. Using sysusers.d ensures
+# these are created declaratively on every boot, making them OTA-safe.
+g wayland -       -
+g seat    -       -
+u weston  -       -       /home/weston /bin/sh
+m weston  video
+m weston  input
+m weston  render
+m weston  seat
+m weston  wayland

--- a/recipes-graphics/wayland/weston-init/weston-tmpfiles.conf
+++ b/recipes-graphics/wayland/weston-init/weston-tmpfiles.conf
@@ -1,0 +1,7 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Create /home/weston, required as the weston user's home directory.
+# Using tmpfiles.d ensures it is created declaratively
+# on every boot, making it OTA-safe.
+d /home/weston 0755 weston weston -


### PR DESCRIPTION
The wayland, seat, and weston groups, weston's membership in them, and /home/weston are needed by weston.service. Previously these were only created via GROUPADD_PARAM/USERADD_PARAM at image build time, which does not survive OSTree OTA updates. Add sysusers.d and tmpfiles.d entries so systemd-sysusers and systemd-tmpfiles create them declaratively on every boot, making them OTA-safe.

Symptom: weston.service failing to start post OTA (1.9 to 2.0) because its required dependencies are not met -- the missing directory entry, groups and group memberships it needs -- and because it now runs as an unprivileged user.

CR-Id: 4591970