### PR TITLE
qcom-multimedia-image: drop userspace-resource-manager-extensions from the image

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bb
+++ b/recipes-products/images/qcom-multimedia-image.bb
@@ -33,7 +33,6 @@ CORE_IMAGE_BASE_INSTALL += " \
     tensorflow-lite-tools \
     thermald \
     userspace-resource-manager \
-    userspace-resource-manager-extensions \
     weston \
     weston-examples \
     weston-init \


### PR DESCRIPTION
qcom-multimedia-image: drop userspace-resource-manager-extensions from the image

Remove userspace-resource-manager-extensions from the multimedia image.
As the URM-Extensions project has been merged into URM, going forward no
separate recipe for userspace-resource-manager-extensions will be maintained,
instead the userspace-resource-manager recipe itself will be responsible
for building and installing the extensions.