### PR TITLE
recipes-quickboot: Add QuickBoot subsystem recipes and demo sample apps

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -19,6 +19,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     kgsl-dlkm \
     libdiag-bin \
     onnxruntime-qnn \
+    packagegroup-qcom-quickboot \
     qcom-adreno \
     qcom-sensors-binaries \
     qwes \

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -1,0 +1,8 @@
+SUMMARY = "Qualcomm Quickboot packagegroup"
+DESCRIPTION = "Package group to bring in quickboot packages"
+
+inherit packagegroup
+
+RDEPENDS:${PN} = "\
+    quickboot-audio \
+    "

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -5,6 +5,7 @@ inherit packagegroup
 
 RDEPENDS:${PN} = "\
     qcom-audio-chime \
+    qcom-camera-preview \
     quickboot-audio \
     quickboot-camera \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -6,4 +6,5 @@ inherit packagegroup
 RDEPENDS:${PN} = "\
     qcom-audio-chime \
     quickboot-audio \
+    quickboot-camera \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -8,4 +8,5 @@ RDEPENDS:${PN} = "\
     qcom-camera-preview \
     quickboot-audio \
     quickboot-camera \
+    quickboot-display \
     "

--- a/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
+++ b/recipes-products/packagegroups/packagegroup-qcom-quickboot.bb
@@ -4,5 +4,6 @@ DESCRIPTION = "Package group to bring in quickboot packages"
 inherit packagegroup
 
 RDEPENDS:${PN} = "\
+    qcom-audio-chime \
     quickboot-audio \
     "

--- a/recipes-quickboot/qcom-audio-chime/qcom-audio-chime_1.0.bb
+++ b/recipes-quickboot/qcom-audio-chime/qcom-audio-chime_1.0.bb
@@ -1,0 +1,44 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Recipe for the QuickBoot early audio chime demo application.
+#
+# The service plays the boot chime once PipeWire is ready, acting as a
+# time-to-first-sound measurement checkpoint for QuickBoot profiling.
+#
+# Note: Service is installed but NOT auto-enabled. Enable manually with:
+#   systemctl enable audio-chime.service
+
+SUMMARY = "Qualcomm QuickBoot Early Audio Chime"
+DESCRIPTION = "Plays a boot chime via PipeWire immediately after the audio \
+pipeline is ready. Used as a time-to-first-sound measurement checkpoint \
+for QuickBoot profiling."
+
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://../LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+
+SRC_URI = "git://github.com/qualcomm/quickboot.git;protocol=https;branch=main"
+SRCREV = "969ed193bff4f491b98b52cdbc864956ac394549"
+
+# Source subdirectory within the cloned repo
+S = "${UNPACKDIR}/qcom-audio-chime-${PV}/qcom-audio-chime"
+
+inherit meson systemd
+
+# ── Meson options ─────────────────────────────────────────────────────────────
+# Pass the Yocto-resolved systemd unit directory so meson does not need
+# pkg-config auto-detection (which may not work in all cross environments).
+EXTRA_OEMESON = "-Dsystemd_system_unit_dir=${systemd_unitdir}/system"
+
+# ── Installed files ───────────────────────────────────────────────────────────
+FILES:${PN} = " \
+    ${bindir}/audio-chime \
+    ${datadir}/sounds/sample-3s.wav \
+    ${systemd_unitdir}/system/audio-chime.service \
+"
+
+SYSTEMD_SERVICE:${PN} = "audio-chime.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"
+
+# Requires PipeWire at runtime for audio playback
+RDEPENDS:${PN} = "pipewire bash"

--- a/recipes-quickboot/qcom-camera-preview/qcom-camera-preview_1.0.bb
+++ b/recipes-quickboot/qcom-camera-preview/qcom-camera-preview_1.0.bb
@@ -1,0 +1,46 @@
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+#
+# Recipe for the QuickBoot early camera preview demo application.
+#
+# Installs:
+#   - camera-preview          → ${bindir}/              (camera preview script)
+#   - camera-preview.service  → ${systemd_unitdir}/system/ (camera preview service)
+#
+# The service starts camera preview when cam-server and Weston are ready,
+# acting as a time-to-first-frame measurement checkpoint for QuickBoot profiling.
+#
+# Note: Service is installed but NOT auto-enabled. Enable manually with:
+#   systemctl enable camera-preview.service
+#
+# Enabled only when DISTRO_FEATURES includes "quickboot" and "quickboot-camera".
+
+SUMMARY = "Qualcomm QuickBoot Early Camera Preview"
+DESCRIPTION = "Displays a live camera preview via Weston immediately after the \
+camera pipeline and display are ready. Used as a time-to-first-frame measurement \
+checkpoint for QuickBoot profiling."
+
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://../LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+
+SRC_URI = "git://github.com/qualcomm/quickboot.git;protocol=https;branch=main"
+SRCREV = "969ed193bff4f491b98b52cdbc864956ac394549"
+
+# Source subdirectory within the cloned repo
+S = "${UNPACKDIR}/qcom-camera-preview-${PV}/qcom-camera-preview"
+
+inherit meson systemd
+
+# ── Meson options ─────────────────────────────────────────────────────────────
+# Pass the Yocto-resolved systemd unit directory so meson does not need
+# pkg-config auto-detection (which may not work in all cross environments).
+EXTRA_OEMESON = "-Dsystemd_system_unit_dir=${systemd_unitdir}/system"
+
+# ── Installed files ───────────────────────────────────────────────────────────
+FILES:${PN} = " \
+    ${bindir}/camera-preview \
+    ${systemd_unitdir}/system/camera-preview.service \
+"
+
+SYSTEMD_SERVICE:${PN} = "camera-preview.service"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"

--- a/recipes-quickboot/quickboot-audio/quickboot-audio_1.0.bb
+++ b/recipes-quickboot/quickboot-audio/quickboot-audio_1.0.bb
@@ -1,0 +1,28 @@
+# This bitbake recipe that packages and installs the quickboot
+# audio optimizations. It ensures the custom 'modules-load.d'
+# configuration, udev rules, early systemd services and the
+# chime wav file are deployed to the rootfs.
+
+SUMMARY = "Early Audio Boot Optimizations"
+DESCRIPTION = "Installs kernel module load list for faster audio driver probes during boot"
+
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://../LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+
+SRC_URI = "git://github.com/qualcomm/quickboot.git;protocol=https;branch=main"
+SRCREV = "969ed193bff4f491b98b52cdbc864956ac394549"
+
+inherit meson
+
+# Add this line to fix the do_unpack warning
+S = "${UNPACKDIR}/quickboot-audio-${PV}/quickboot-audio"
+
+# ── Meson options ────────────────────────────────────────────────────────────
+# Pass the Yocto-resolved systemd unit directory so meson does not need
+# pkg-config auto-detection (which may not work in all cross environments).
+EXTRA_OEMESON = "-Dsystemd_system_unit_dir=${systemd_unitdir}/system"
+
+# ── Installed files ──────────────────────────────────────────────────────────
+FILES:${PN} = " \
+        ${sysconfdir}/modules-load.d/qcom-audio.conf \
+        "

--- a/recipes-quickboot/quickboot-camera/quickboot-camera_1.0.bb
+++ b/recipes-quickboot/quickboot-camera/quickboot-camera_1.0.bb
@@ -1,0 +1,35 @@
+# Recipe for early camera boot optimizations and preview application.
+# Installs systemd services, udev rules, kernel module load lists,
+# and helper scripts to achieve fast time-to-first-frame on boot.
+
+SUMMARY = "Early Camera Boot Optimizations"
+DESCRIPTION = "Installs udev rules, kernel module load list, cam-server \
+systemd unit, and setup scripts to bring up the camera pipeline early in \
+the boot sequence."
+
+SRC_URI = "git://github.com/qualcomm/quickboot.git;protocol=https;branch=main"
+SRCREV = "969ed193bff4f491b98b52cdbc864956ac394549"
+
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://../LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+
+inherit meson systemd
+
+S = "${UNPACKDIR}/quickboot-camera-${PV}/quickboot-camera"
+
+# ── Meson options ────────────────────────────────────────────────────────────
+# Pass the Yocto-resolved systemd unit directory so meson does not need
+# pkg-config auto-detection (which may not work in all cross environments).
+EXTRA_OEMESON = "-Dsystemd_system_unit_dir=${systemd_unitdir}/system"
+
+FILES:${PN} += " \
+    ${sysconfdir}/modules-load.d/qcom-camera.conf\
+    ${sysconfdir}/udev/rules.d/02-cam-server.rules \
+    ${sysconfdir}/systemd/system/cam-server.service \
+    ${bindir}/camx-set-vendor-dtbo.sh \
+    ${bindir}/camera-sensors-prune.sh \
+    "
+
+SYSTEMD_SERVICE:${PN} = "cam-server.service"
+
+RDEPENDS:${PN} += "udev"

--- a/recipes-quickboot/quickboot-display/quickboot-display_1.0.bb
+++ b/recipes-quickboot/quickboot-display/quickboot-display_1.0.bb
@@ -1,0 +1,37 @@
+# Recipe for early display boot optimizations.
+#
+# Installs custom Weston service configurations, udev rules for
+# immediate triggering, and kernel module load lists to achieve
+# early display availability.
+
+SUMMARY = "Early Display Boot Optimizations"
+DESCRIPTION = "Installs udev rules, kernel module load list, and Weston \
+systemd units to bring up the display pipeline early in the boot sequence, \
+reducing time-to-first-frame"
+
+LICENSE = "BSD-3-Clause-Clear"
+LIC_FILES_CHKSUM = "file://../LICENSE.txt;md5=2998c54c288b081076c9af987bdf4838"
+
+SRC_URI = "git://github.com/qualcomm/quickboot.git;protocol=https;branch=main"
+SRCREV = "969ed193bff4f491b98b52cdbc864956ac394549"
+
+inherit meson systemd
+
+# Add this line to fix the do_unpack warning
+S = "${UNPACKDIR}/quickboot-display-${PV}/quickboot-display"
+
+# ── Meson options ────────────────────────────────────────────────────────────
+# Pass the Yocto-resolved systemd unit directory so meson does not need
+# pkg-config auto-detection (which may not work in all cross environments).
+EXTRA_OEMESON = "-Dsystemd_system_unit_dir=${systemd_unitdir}/system"
+
+# ── Installed files ──────────────────────────────────────────────────────────
+FILES:${PN} = " \
+    ${sysconfdir}/modules-load.d/qcom-display.conf \
+    ${sysconfdir}/udev/rules.d/03-drm.rules \
+    ${sysconfdir}/systemd/system/weston.socket \
+    ${sysconfdir}/systemd/system/weston.service \
+"
+SYSTEMD_SERVICE:${PN} = "weston.service"
+
+RDEPENDS:${PN} += "udev"


### PR DESCRIPTION

This PR integrates the QuickBoot early boot optimization framework into
meta-qcom-distro, adding Yocto recipes for all three subsystems and two
demo sample applications to measure boot KPIs.

## Changes

### Subsystem Recipes
- **quickboot-audio**: Pre-loads audio kernel modules via modules-load.d,
  ensuring ALSA/ASoC drivers are probed before PipeWire starts, reducing
  time-to-first-sound.
- **quickboot-camera**: Installs cam-server systemd service, udev rules,
  and camera setup scripts for early camera pipeline bring-up, reducing
  time-to-first-frame.
- **quickboot-display**: Installs Weston compositor service, DRM udev
  rules, and display kernel module configs for early display bring-up.

### Demo Sample Apps (disabled by default)
- **qcom-audio-chime**: Plays a WAV chime via PipeWire as soon as the
  audio pipeline is ready. Used as a time-to-first-sound checkpoint.
  Enable with: `systemctl enable audio-chime.service`
- **qcom-camera-preview**: Displays a live camera preview via Weston as
  soon as the camera pipeline is ready. Used as a time-to-first-frame
  checkpoint. Enable with: `systemctl enable camera-preview.service`

### Packagegroup
- Added all five recipes to `packagegroup-qcom-quickboot` and included
  the packagegroup in `qcom-multimedia-proprietary-image`.

## Testing
- Built and verified on Qualcomm target platform IQ9075 initially.
- quickboot-audio, quickboot-camera, quickboot-display compile and
  install correctly
- Demo apps install service files; services remain disabled until
  explicitly enabled by the user