### PR TITLE
Wrynose wpa-supplicant: hostapd: add 2.12 bbappend override on wrynose

### DIFF
--- a/recipes-connectivity/hostapd/hostapd_%.bbappend
+++ b/recipes-connectivity/hostapd/hostapd_%.bbappend
@@ -1,0 +1,12 @@
+PV = "2.12"
+
+LIC_FILES_CHKSUM = "file://hostapd/README;beginline=5;endline=47;md5=4d666937756a064d6d90d128a32c3571"
+
+SRC_URI:remove = " \
+    file://0001-Include-base64-for-hostapd-CONFIG_SAE_PK-builds.patch \
+    file://0002-hostapd-Fix-clearing-up-settings-for-color-switch.patch \
+    file://CVE-2025-24912-01.patch \
+    file://CVE-2025-24912-02.patch \
+"
+
+SRC_URI[sha256sum] = "f43502561c28ba47ab77e18e1a973d07361c68cc8b14178e619bd5796b70eabd"

--- a/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
+++ b/recipes-connectivity/wpa-supplicant/wpa-supplicant_%.bbappend
@@ -1,0 +1,16 @@
+PV = "2.12"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=5ebcb90236d1ad640558c3d3cd3035df \
+                    file://README;beginline=1;endline=56;md5=155e35cb3d6ab0d6a17524f48f4e761c \
+                    file://wpa_supplicant/wpa_supplicant.c;beginline=1;endline=12;md5=f5ccd57ea91e04800edb88267bf8eae4"
+
+SRC_URI:remove = " \
+    file://0001-macsec_linux-Hardware-offload-requires-Linux-headers.patch \
+    file://0002-defconfig-Update-Opportunistic-Wireless-Encryption-O.patch \
+    file://0003-defconfig-Document-IEEE-802.11be-as-a-published-amen.patch \
+    file://0004-defconfig-Uncomment-CONFIG_IEEE80211BE-y.patch \
+    file://CVE-2025-24912-01.patch \
+    file://CVE-2025-24912-02.patch \
+"
+
+SRC_URI[sha256sum] = "08e23937e16d0155e55cab2b51f51fbe10d80a1aa91c4e15442645059b737ef6"


### PR DESCRIPTION
openembedded-core wrynose is an LTS branch, and maintainers rejected
upgrading wpa-supplicant there.

meta-qcom still needs Wi-Fi 7 related functionality for customer
deliverables. Add a bbappend in this layer to override to upstream
wpa_supplicant 2.12 tarball on wrynose.

2.12 includes most fixes and feature support needed by our Wi-Fi 7
enablement while keeping this change local to meta-qcom.

Remove patch entries now included in 2.12 and update
LIC_FILES_CHKSUM for the 2.12 README text.


meta-openembedded wrynose is an LTS branch, and maintainers rejected
upgrading hostapd there.

meta-qcom still needs Wi-Fi 7 related functionality for customer
deliverables. Add a bbappend in this layer to override to upstream
hostapd 2.12 tarball on wrynose.

2.12 includes most fixes and feature support needed by our Wi-Fi 7
enablement while keeping this change local to meta-qcom.

Remove patch entries now included in 2.12 and update
LIC_FILES_CHKSUM for the 2.12 README text.