### PR TITLE
redis: disable xxhash inline hints under -Og debug builds

### DIFF
--- a/recipes-extended/redis/redis_%.bbappend
+++ b/recipes-extended/redis/redis_%.bbappend
@@ -3,3 +3,8 @@ FILESEXTRAPATHS:prepend:qcom-distro := "${THISDIR}/files:"
 SRC_URI:append:qcom-distro = " file://0006-tests-modules-do-not-force-host-gcc.patch"
 
 SYSTEMD_AUTO_ENABLE:${PN}:qcom-distro = "disable"
+
+# xxhash's always_inline NEON helpers fail to inline under -Og (from
+# DEBUG_BUILD = "1"), which GCC treats as a hard error since
+# XXH_NO_INLINE_HINTS only disables forced inlining for -Os/-Oz, not -Og.
+CFLAGS:append:qcom-distro = " -DXXH_NO_INLINE_HINTS=1"


### PR DESCRIPTION
xxhash's `always_inline` NEON helpers fail to inline under `-Og` (produced by `DEBUG_BUILD = "1"`), which GCC treats as a hard compile error since `XXH_NO_INLINE_HINTS` only disables forced inlining for `-Os`/`-Oz`, not `-Og`.

Sets `CFLAGS:append:qcom-distro = " -DXXH_NO_INLINE_HINTS=1"` in the redis bbappend so debug (`-Og`) builds compile cleanly.

This is a generic toolchain/debug-build interaction, not board-specific — encountered while bringing up iq10-rrd (NORD) with `DEBUG_BUILD = "1"`, but applies to any qcom-distro build using `-Og`.