### PR TITLE
qcom-multimedia-image: follow the LicenseRef licence rename

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -9,28 +9,27 @@ BAD_RECOMMENDATIONS += " \
 "
 
 # Error out if any of the closed source packages get pulled into the image
-INCOMPATIBLE_LICENSE = "LICENSE.qcom LICENSE.qcom-2"
+INCOMPATIBLE_LICENSE = "LicenseRef-LICENSE.qcom LicenseRef-LICENSE.qcom-2"
 
 # Allow closed source firmware packages
 INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
-    camxfirmware-hamoa:LICENSE.qcom-2 \
-    camxfirmware-kodiak:LICENSE.qcom-2 \
-    camxfirmware-lemans:LICENSE.qcom-2 \
-    camxfirmware-monaco:LICENSE.qcom-2 \
-    camxfirmware-talos:LICENSE.qcom-2 \
-    firmware-qcom-boot-glymur:LICENSE.qcom-2 \
-    firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
-    firmware-qcom-boot-kaanapali:LICENSE.qcom-2 \
-    firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
-    firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
-    firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \
-    firmware-qcom-boot-qcs9100:LICENSE.qcom-2 \
-    firmware-qcom-boot-qrb2210:LICENSE.qcom-2 \
-    firmware-qcom-boot-qrb2210-rb1:LICENSE.qcom \
-    firmware-qcom-boot-shikra:LICENSE.qcom-2 \
-    firmware-qcom-boot-sm8750:LICENSE.qcom-2 \
-    trusted-firmware-a-qcom:LICENSE.qcom \
-    trusted-firmware-a-qcom-rb3gen2:LICENSE.qcom \
+    camxfirmware-hamoa:LicenseRef-LICENSE.qcom-2 \
+    camxfirmware-kodiak:LicenseRef-LICENSE.qcom-2 \
+    camxfirmware-lemans:LicenseRef-LICENSE.qcom-2 \
+    camxfirmware-monaco:LicenseRef-LICENSE.qcom-2 \
+    camxfirmware-talos:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-glymur:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-iq-x7181:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-kaanapali:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-qcs615:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-qcs6490:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-qcs8300:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-qcs9100:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-qrb2210:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-qrb2210-rb1:LicenseRef-LICENSE.qcom \
+    firmware-qcom-boot-shikra:LicenseRef-LICENSE.qcom-2 \
+    firmware-qcom-boot-sm8750:LicenseRef-LICENSE.qcom-2 \
+    trusted-firmware-a-qcom-rb3gen2:LicenseRef-LICENSE.qcom \
 "
 
 # QA check considers packages in INCOMPATIBLE_LICENSE_EXCEPTIONS list still to


### PR DESCRIPTION
meta-qcom#2802 renamed the closed licences to `LicenseRef-*`. `INCOMPATIBLE_LICENSE` and every exception here still use the old names, and vendor names are not in `SPDXLICENSEMAP`, so nothing canonicalises them: the gate currently matches no recipe and lets closed blobs through unnoticed.

Rename both sides, and drop `trusted-firmware-a-qcom`, which meta-qcom#2910 replaced with per-device recipes (`-rb3gen2` is already listed).