### PR TITLE
dpdk: enable afxdp PACKAGECONFIG for qcom-distro

### DIFF
--- a/dynamic-layers/dpdk/recipes-extended/dpdk/dpdk_%.bbappend
+++ b/dynamic-layers/dpdk/recipes-extended/dpdk/dpdk_%.bbappend
@@ -1,1 +1,1 @@
-PACKAGECONFIG:append:qcom-distro = " shared"
+PACKAGECONFIG:append:qcom-distro = " shared afxdp"


### PR DESCRIPTION
Enable the afxdp PACKAGECONFIG option to include AF_XDP support in DPDK builds.
AF_XDP provides a low-overhead packet path between user space applications and the Linux networking stack through XDP sockets. Enabling this option allows DPDK applications that use the AF_XDP Poll Mode Driver (PMD) for high-performance packet processing to run on qcom-distro.