### PR TITLE
pipewire: add audio to supplementary groups in dmaheap.conf

### DIFF
--- a/recipes-multimedia/pipewire/pipewire/dmaheap.conf
+++ b/recipes-multimedia/pipewire/pipewire/dmaheap.conf
@@ -4,4 +4,4 @@
 # Allow PipeWire to access DMA-HEAP for system-wide daemon mode
 
 [Service]
-SupplementaryGroups=dmaheap
+SupplementaryGroups=dmaheap audio


### PR DESCRIPTION
Add the audio group to the supplementary groups configuration to ensure PipeWire processes have the required permissions for audio-related resource access.