### PR TITLE
qcom-distro-sota: drop the unused ext4 image

### DIFF
--- a/conf/distro/include/qcom-distro-sota.inc
+++ b/conf/distro/include/qcom-distro-sota.inc
@@ -9,3 +9,6 @@ DISTRO_FEATURES_OPTED_OUT += "ptest"
 
 # Generate an OSTree repository tarball during image build
 BUILD_OSTREE_REPO_TARBALL = "1"
+
+# sota flashes ota-ext4, so the ext4 from the machine config is never read
+IMAGE_FSTYPES:remove = "ext4"


### PR DESCRIPTION
The machine configuration adds ext4 because that is what qcomflash flashes, but a sota image flashes ota-ext4 instead, so the plain image is built and never read.

Remove it. On a qcs9100-ride-sx catchall build that saves 14.9 GB of writes across the three images.

Assisted-by: Claude Code:claude-fable-5