### PR TITLE
recipes-core/systemd: reuse the prebuilt ldconfig cache on SOTA deployments

### DIFF
--- a/recipes-core/systemd/systemd/10-use-prebuilt-ldconfig-cache.conf
+++ b/recipes-core/systemd/systemd/10-use-prebuilt-ldconfig-cache.conf
@@ -1,0 +1,6 @@
+[Service]
+# OpenEmbedded already generated the cache stored in /usr/etc. Copying that
+# cache is substantially cheaper than rescanning every library after OSTree
+# deliberately removes /etc/.updated from a new deployment.
+ExecStart=
+ExecStart=/usr/libexec/qcom-ldconfig-update

--- a/recipes-core/systemd/systemd/qcom-ldconfig-update
+++ b/recipes-core/systemd/systemd/qcom-ldconfig-update
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+vendor_cache=/usr/etc/ld.so.cache
+runtime_cache=/etc/ld.so.cache
+
+if [ -s "$vendor_cache" ] && [ -s "$runtime_cache" ]; then
+    tmp_cache="${runtime_cache}.new.$$"
+
+    # Replace the cache atomically. Dynamic loaders may have the old cache
+    # mapped while this service runs, so rewriting it in place can cause
+    # readers to receive SIGBUS.
+    if cp -p "$vendor_cache" "$tmp_cache" &&
+       mv -f "$tmp_cache" "$runtime_cache"; then
+        exit 0
+    fi
+
+    rm -f "$tmp_cache"
+fi
+
+# Retain the upstream recovery behavior if either cache is missing or empty.
+exec ldconfig -X

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,20 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:qcom-distro:sota = " \
+    file://10-use-prebuilt-ldconfig-cache.conf \
+    file://qcom-ldconfig-update \
+"
+
+do_install:append:qcom-distro:sota() {
+    install -Dm 0644 \
+        ${UNPACKDIR}/10-use-prebuilt-ldconfig-cache.conf \
+        ${D}${systemd_system_unitdir}/ldconfig.service.d/10-use-prebuilt-ldconfig-cache.conf
+    install -Dm 0755 \
+        ${UNPACKDIR}/qcom-ldconfig-update \
+        ${D}${libexecdir}/qcom-ldconfig-update
+}
+
+FILES:${PN}:append:qcom-distro:sota = " \
+    ${systemd_system_unitdir}/ldconfig.service.d/10-use-prebuilt-ldconfig-cache.conf \
+    ${libexecdir}/qcom-ldconfig-update \
+"


### PR DESCRIPTION
systemd: restore the prebuilt `ldconfig` cache atomically

Override `ldconfig.service` for **qcom-distro SOTA** images to reuse the linker cache generated during `rootfs` construction instead of scanning all libraries again on **first boot**, effectively **saving 600-700ms** running the service.

Copy the cache to a temporary file and atomically rename it into place so concurrently starting processes cannot observe a truncated cache. Fall back to `ldconfig -X` when either cache is unavailable.