### PR TITLE
ci: qcom-distro: carry the meta-qcom kas patches for meta-oe and meta-selinux

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -18,6 +18,9 @@ repos:
       redis-xxhash-og:
         repo: meta-qcom-distro
         path: patches/meta-oe/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
+      redis-install-prefix:
+        repo: meta-qcom-distro
+        path: patches/meta-oe/0002-redis-fix-the-install-prefix-with-8.10.0.patch
     layers:
       meta-filesystems:
       meta-gnome:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -14,6 +14,10 @@ repos:
 
   meta-openembedded:
     url: https://github.com/openembedded/meta-openembedded
+    patches:
+      redis-xxhash-og:
+        repo: meta-qcom-distro
+        path: patches/meta-oe/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
     layers:
       meta-filesystems:
       meta-gnome:

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -46,6 +46,9 @@ repos:
       libselinux-nativesdk:
         repo: meta-qcom-distro
         path: patches/selinux/0002-libselinux-enable-nativesdk.patch
+      libselinux-python-swig-4.5:
+        repo: meta-qcom-distro
+        path: patches/selinux/0003-libselinux-python-fix-the-build-against-swig-4.5.0.patch
 
   meta-updater:
     url: https://github.com/uptane/meta-updater

--- a/patches/meta-oe/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
+++ b/patches/meta-oe/0001-redis-fix-build-of-the-bundled-xxHash-with-Og.patch
@@ -1,0 +1,64 @@
+From 233354282659b333a9633343b407f8d0598eb281 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Date: Sat, 15 Aug 2026 03:47:52 +0000
+Subject: [PATCH] redis: fix build of the bundled xxHash with -Og
+
+redis 8.4 started bundling an xxHash snapshot in deps/xxhash, which is
+built and linked into redis-server. The snapshot reports itself as 0.8.3
+but does not match that release: it carries RISC-V Vector and LoongArch
+LASX backends that landed after the v0.8.3 tag, so the system xxhash is
+not a substitute for it.
+
+Its XXH3 accumulate and scramble routines are marked always_inline but
+are only ever reached through function pointers, so the compiler has to
+resolve the indirect call before it can honour the attribute.
+
+xxHash drops those inline hints on its own when __NO_INLINE__ is
+defined, which covers -O0 and -fno-inline, but nothing covers -Og.
+Recent GCC no longer resolves the indirect calls at that optimisation
+level, so every build with DEBUG_BUILD = "1" fails:
+
+  xxhash.h:5476:1: error: inlining failed in call to 'always_inline'
+  'XXH3_scrambleAcc_neon': function not considered for inlining
+  make[2]: *** [Makefile:108: xxhash] Error 2
+  ld: cannot find ../deps/xxhash/libxxhash.a: No such file or directory
+
+Upstream xxHash closed this as not fixable in code (Cyan4973/xxHash#943)
+and instead documents XXH_NO_INLINE_HINTS as the supported way to
+compile with -Og. Define it when -Og is the selected optimisation,
+leaving regular builds untouched so xxHash keeps its inline hints there.
+
+oe-core already carries exactly this workaround for the standalone
+xxhash recipe, added in 3464c67cd3 ("xxhash: fix build with gcc 12")
+for the same -Og inlining failure, so use the identical expression here
+rather than a second spelling of the same condition. The bundled copy
+needs its own because redis builds deps/xxhash from its own tree and
+never links the system library.
+
+AI-Generated: Uses Claude Code
+Signed-off-by: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lists.openembedded.org/g/openembedded-devel/message/129176]
+---
+ meta-oe/recipes-extended/redis/redis_8.10.0.bb | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/meta-oe/recipes-extended/redis/redis_8.10.0.bb b/meta-oe/recipes-extended/redis/redis_8.10.0.bb
+index 6176dc45be..63bf6d11a9 100644
+--- a/meta-oe/recipes-extended/redis/redis_8.10.0.bb
++++ b/meta-oe/recipes-extended/redis/redis_8.10.0.bb
+@@ -43,6 +43,15 @@ EXTRA_OEMAKE += "${PACKAGECONFIG_CONFARGS}"
+ 
+ TARGET_LDFLAGS:append = " ${DEBUG_PREFIX_MAP}"
+ 
++# The bundled xxHash marks its XXH3 vector paths always_inline but only reaches
++# them through function pointers. It drops the inline hints on its own when
++# __NO_INLINE__ is defined (-O0, -fno-inline) but never for -Og, and recent GCC
++# no longer resolves those indirect calls at -Og, so deps/xxhash fails to
++# build. Upstream xxHash closed this as not fixable in code and documents
++# XXH_NO_INLINE_HINTS as the supported way to compile with -Og. This is the
++# same workaround oe-core applies to the standalone xxhash recipe.
++CFLAGS += "${@bb.utils.contains('SELECTED_OPTIMIZATION', '-Og', '-DXXH_NO_INLINE_HINTS', '', d)}"
++
+ do_compile:prepend() {
+     oe_runmake -C deps hdr_histogram fpconv hiredis lua linenoise
+ }

--- a/patches/meta-oe/0002-redis-fix-the-install-prefix-with-8.10.0.patch
+++ b/patches/meta-oe/0002-redis-fix-the-install-prefix-with-8.10.0.patch
@@ -1,0 +1,43 @@
+From cc7712f1158c6897a91c895db27a1c432cb84818 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Date: Fri, 21 Aug 2026 15:34:03 +0000
+Subject: [PATCH] redis: fix the install prefix with 8.10.0
+
+redis 8.10.0 replaced the top level Makefile with one that dispatches
+through scripts/ and no longer passes an environment PREFIX down to the
+recursive make in src/, so everything lands in the default /usr/local
+instead of ${D}:
+
+  install: cannot create regular file '/usr/local/bin/redis-server': \
+      Permission denied
+  make[1]: *** [Makefile:576: install] Error 1
+
+This reproduces outside of bitbake: with PREFIX exported, "make install"
+from the top level installs to /usr/local/bin, while "make -C src
+install" honours it. Passing PREFIX as a make command line variable
+works in both cases, because command line variables are propagated to
+sub-makes.
+
+Set it on the oe_runmake command line instead of exporting it.
+
+AI-Generated: Uses Claude Code
+Signed-off-by: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Upstream-Status: Submitted [https://lists.openembedded.org/g/openembedded-devel/message/129474]
+---
+ meta-oe/recipes-extended/redis/redis_8.10.0.bb | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/meta-oe/recipes-extended/redis/redis_8.10.0.bb b/meta-oe/recipes-extended/redis/redis_8.10.0.bb
+index 6176dc45be..13d6aa1066 100644
+--- a/meta-oe/recipes-extended/redis/redis_8.10.0.bb
++++ b/meta-oe/recipes-extended/redis/redis_8.10.0.bb
+@@ -56,8 +56,7 @@ do_compile() {
+ }
+ 
+ do_install() {
+-    export PREFIX=${D}/${prefix}
+-    oe_runmake install
++    oe_runmake install PREFIX=${D}${prefix}
+     install -d ${D}/${sysconfdir}/redis
+     install -m 0644 ${UNPACKDIR}/redis.conf ${D}/${sysconfdir}/redis/redis.conf
+     install -d ${D}/${sysconfdir}/init.d

--- a/patches/selinux/0003-libselinux-python-fix-the-build-against-swig-4.5.0.patch
+++ b/patches/selinux/0003-libselinux-python-fix-the-build-against-swig-4.5.0.patch
@@ -1,0 +1,97 @@
+From 7ae827214cfe0efe6758109eadc530517d786c4b Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Date: Sun, 16 Aug 2026 22:00:00 +0000
+Subject: [PATCH] libselinux-python: fix the build against swig 4.5.0
+
+swig 4.5.0 removed the Python 2 C API compatibility macros from its
+pyhead.swg runtime header, and libselinux 3.10 still calls
+PyString_FromString() from selinuxswig_python.i, so the generated
+wrapper no longer compiles:
+
+  selinuxswig_python_wrap.c:11583:34: error: passing argument 3 of
+  'PyList_SetItem' makes pointer from integer without a cast
+
+Backport the upstream fix, which switches the three call sites to
+PyUnicode_FromString().
+
+Signed-off-by: Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+Upstream-Status: Backport [https://github.com/SELinuxProject/selinux/commit/fb518ff492cd6a286f35b415cbd7fd0f6e3faedb]
+---
+ .../selinux/libselinux-python_3.10.bb         |  1 +
+ ...e-PyString_FromString-with-PyUnicode.patch | 55 +++++++++++++++++++
+ 2 files changed, 56 insertions(+)
+ create mode 100644 recipes-security/selinux/libselinux/0004-libselinux-Replace-PyString_FromString-with-PyUnicode.patch
+
+diff --git a/recipes-security/selinux/libselinux-python_3.10.bb b/recipes-security/selinux/libselinux-python_3.10.bb
+index 139e6df..e0fcb4b 100644
+--- a/recipes-security/selinux/libselinux-python_3.10.bb
++++ b/recipes-security/selinux/libselinux-python_3.10.bb
+@@ -15,6 +15,7 @@ SRC_URI += "\
+         file://0001-Makefile-fix-python-modules-install-path-for-multili.patch;patchdir=.. \
+         file://0002-Do-not-use-PYCEXT-and-rely-on-the-installed-file-nam.patch;patchdir=.. \
+         file://0003-libselinux-restore-drop-the-obsolete-LSF-transitiona.patch;patchdir=.. \
++        file://0004-libselinux-Replace-PyString_FromString-with-PyUnicode.patch;patchdir=.. \
+         "
+ 
+ S = "${UNPACKDIR}/${BP}/libselinux"
+diff --git a/recipes-security/selinux/libselinux/0004-libselinux-Replace-PyString_FromString-with-PyUnicode.patch b/recipes-security/selinux/libselinux/0004-libselinux-Replace-PyString_FromString-with-PyUnicode.patch
+new file mode 100644
+index 0000000..3c3738f
+--- /dev/null
++++ b/recipes-security/selinux/libselinux/0004-libselinux-Replace-PyString_FromString-with-PyUnicode.patch
+@@ -0,0 +1,55 @@
++From fb518ff492cd6a286f35b415cbd7fd0f6e3faedb Mon Sep 17 00:00:00 2001
++From: Petr Lautrbach <lautrbach@redhat.com>
++Date: Thu, 6 Aug 2026 16:30:44 +0200
++Subject: [PATCH] libselinux: Replace PyString_FromString with
++ PyUnicode_FromString for SWIG 4.5.0 compatibility
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++SWIG 4.5.0 removed Python 2 C API compatibility macros (PyInt_*,
++PyString_*, SWIG_Python_str_*) from its runtime header pyhead.swg.
++These macros previously mapped deprecated Python 2 C API names to their
++Python 3 equivalents.
++
++Fixes: https://github.com/SELinuxProject/selinux/issues/538
++Authored-by: Jitka Plesníková <jplesnik@redhat.com>
++Upstream-Status: Backport [https://github.com/SELinuxProject/selinux/commit/fb518ff492cd6a286f35b415cbd7fd0f6e3faedb]
++
++Signed-off-by: Petr Lautrbach <lautrbach@redhat.com>
++Acked-by: Stephen Smalley <stephen.smalley.work@gmail.com>
++---
++ libselinux/src/selinuxswig_python.i | 6 +++---
++ 1 file changed, 3 insertions(+), 3 deletions(-)
++
++diff --git a/libselinux/src/selinuxswig_python.i b/libselinux/src/selinuxswig_python.i
++index c8c08a407..74d923e42 100644
++--- a/libselinux/src/selinuxswig_python.i
+++++ b/libselinux/src/selinuxswig_python.i
++@@ -69,7 +69,7 @@ def install(src, dest):
++ 	PyObject* list = PyList_New(*$2);
++ 	int i;
++ 	for (i = 0; i < *$2; i++) {
++-		PyList_SetItem(list, i, PyString_FromString((*$1)[i]));
+++		PyList_SetItem(list, i, PyUnicode_FromString((*$1)[i]));
++ 	}
++ 	$result = SWIG_AppendOutput($result, list);
++ }
++@@ -123,7 +123,7 @@ def install(src, dest):
++ 			len++;
++ 		plist = PyList_New(len);
++ 		for (i = 0; i < len; i++) {
++-			PyList_SetItem(plist, i, PyString_FromString((*$1)[i]));
+++			PyList_SetItem(plist, i, PyUnicode_FromString((*$1)[i]));
++ 		}
++ 	} else {
++ 		plist = PyList_New(0);
++@@ -140,7 +140,7 @@ def install(src, dest):
++ 	if (*$1) {
++ 		plist = PyList_New(result);
++ 		for (i = 0; i < result; i++) {
++-			PyList_SetItem(plist, i, PyString_FromString((*$1)[i]));
+++			PyList_SetItem(plist, i, PyUnicode_FromString((*$1)[i]));
++ 		}
++ 	} else {
++ 		plist = PyList_New(0);


### PR DESCRIPTION
The CI composition inherits the layer revisions pinned by meta-qcom's
ci/base.lock.yml (through the ci/base.yml include), but not the kas
managed patches meta-qcom applies in its own ci/qcom-distro.yml, since
this repository uses its own. The latest lock update brought in swig
4.5.0 and redis 8.10.0, breaking every build-pr job on libselinux-python
do_compile (see #439), with the redis install failure right behind it.

Cherry-pick the three workaround patches from meta-qcom, adapting the
patch entries to reference this repository. Each is temporary and should
be dropped once the corresponding upstream submission merges and the
layer pin is bumped.