### PR TITLE
ci: switch sstate cache from EFS to fsxOpenZFS

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_DIR: /efs/qli/meta-qcom
+  CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
 
 jobs:


### PR DESCRIPTION
This change will reduce sstate cache costs. As AWS EFS costs increase with throughput and data transfer growth, IT evaluated FSx OpenZFS as an alternative and expects 70–80% savings compared to EFS.