### PR TITLE
[Backport wrynose] ci: switch sstate cache from EFS to fsxOpenZFS

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  CACHE_DIR: /efs/qli/meta-qcom
+  CACHE_DIR: /efsx/qli/meta-qcom
   KAS_CLONE_DEPTH: 1
 
 jobs:


### PR DESCRIPTION
Backport of https://github.com/qualcomm-linux/meta-qcom-distro/pull/445 to wrynose.