### PR TITLE
[Backport wrynose] ci: sync .github workflows from master

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -277,9 +277,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully
+        env:
+          COMPILE_RESULT: ${{ needs.compile.result }}
         run: |
-          if [ "${{ needs.compile.result }}" != "success" ]; then
-            echo "compile result was ${{ needs.compile.result }}"
+          if [ "${COMPILE_RESULT}" != "success" ]; then
+            echo "compile result was ${COMPILE_RESULT}"
             exit 1
           fi
           echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -158,6 +158,9 @@ jobs:
           - type: default
             dirname: ""
             yamlfile: ""
+          - type: qcom-next
+            dirname: "_linux-qcom-next"
+            yamlfile: ":ci/linux-qcom-next.yml"
           - type: rt-6.18
             dirname: "_linux-qcom-rt-6.18"
             yamlfile: ":ci/linux-qcom-rt-6.18.yml"
@@ -178,6 +181,16 @@ jobs:
                 name: qcom-distro
             kernel:
                 type: default
+          # qcom-distro coverage is enough for the non-default qcom-next
+          # kernel; 6.18 is the official and supported kernel on this branch
+          - distro:
+                name: qcom-distro-catchall
+            kernel:
+                type: qcom-next
+          - distro:
+                name: performance
+            kernel:
+                type: qcom-next
         include:
           # Additional builds for specific machines
           - machine: qcom-armv8a

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -250,7 +250,7 @@ jobs:
 
   publish_summary:
     needs: compile
-    if: always()
+    if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
     runs-on: ubuntu-latest
     steps:
       - uses: qualcomm-linux/meta-qcom/.github/actions/print-build-output@master
@@ -259,6 +259,7 @@ jobs:
           pattern: build-url*
 
   build_successful:
+    if: github.repository_owner == 'qualcomm-linux'
     needs: compile
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -259,9 +259,14 @@ jobs:
           pattern: build-url*
 
   build_successful:
-    if: github.repository_owner == 'qualcomm-linux'
+    if: ${{ always() && github.repository_owner == 'qualcomm-linux' }}
     needs: compile
     runs-on: ubuntu-latest
     steps:
       - name: Build completed successfully
-        run: echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"
+        run: |
+          if [ "${{ needs.compile.result }}" != "success" ]; then
+            echo "compile result was ${{ needs.compile.result }}"
+            exit 1
+          fi
+          echo "All compile matrix jobs succeeded and artifacts uploaded to S3 bucket"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,11 +12,7 @@ on:
       - 'SECURITY.md'
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
-  actions: read
 
 jobs:
   event-file:
@@ -28,16 +24,24 @@ jobs:
       with:
         name: Event File
         path: ${{ github.event_path }}
-        
+
   pr-to-workflow-dependency:
     name: "PR To Workflow Dependency"
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     uses: qualcomm/qcom-reusable-workflows/.github/workflows/qswat-reusable-pr-to-workflow-dependency.yml@qswat-release-v1
     with:
       workflow_id: ${{ github.run_id }}
       run_attempt: ${{ github.run_attempt }}
       pr_number: ${{ github.event.pull_request.number }}
-      
+
   build-pr:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     uses: ./.github/workflows/build-yocto.yml
     with:
       profile: pr

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo $GITHUB_WORKSPACE
           ls -R $GITHUB_WORKSPACE
-          if ! find "${{ github.workspace }}/artifacts/" -name '*.xml' -print -quit | grep -q .; then
+          if ! find "${GITHUB_WORKSPACE}/artifacts/" -name '*.xml' -print -quit | grep -q .; then
             echo "Error: no .xml files found"
             exit 1
           fi

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -15,6 +15,10 @@ on:
       commit:
         required: true
         type: string
+    secrets:
+      TEST_REPORTING_APP_TOKEN:
+        required: true
+        description: "Private key of the GitHub App used to report test results"
 
 permissions:
   checks: write

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -52,11 +52,17 @@ jobs:
           fi
 
       - id: app_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         if: always()
         with:
-          app-id: 2291458
+          client-id: 2291458
           private-key: ${{ secrets.TEST_REPORTING_APP_TOKEN }}
+          # Scope the token to what publish-unit-test-result-action uses on a
+          # public repository instead of inheriting every permission of the app
+          # installation. contents and issues are only needed on private repos,
+          # and the app is not granted issues at all.
+          permission-checks: write
+          permission-pull-requests: write
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
@@ -71,3 +77,5 @@ jobs:
           action_fail: true
           action_fail_on_inconclusive: true
           github_token: ${{ steps.app_token.outputs.token }}
+          report_individual_runs: true
+          report_suite_logs: any

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,4 @@
 name: Build on push
-run-name: "${{ github.ref_name }}: ${{ github.event.head_commit.message }}"
 
 on:
   push:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,21 +9,33 @@ on:
       - wrynose
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
     uses: ./.github/workflows/build-yocto.yml
   test:
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test.yml
     needs: [build]
     secrets: inherit
     with:
       build_id: ${{ github.run_id }}
   publish-test-results:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     needs: test
     secrets: inherit

--- a/.github/workflows/stales.yml
+++ b/.github/workflows/stales.yml
@@ -23,3 +23,4 @@ jobs:
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true
         remove-pr-stale-when-updated: true
+        operations-per-run: 100

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -1,0 +1,286 @@
+name: Tests distro
+
+on:
+  workflow_call:
+    inputs:
+      build_id:
+        required: true
+        type: string
+      devices:
+        required: true
+        type: string
+        description: Comma separated list of devices to be used for testing
+        # example
+        # iq-8275-evk,iq-9075-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx
+      devices_premerge:
+        required: false
+        type: string
+        description: Comma separated list of devices to be used for testing. Set when different from devices running boot test.
+      distro_name:
+        required: true
+        type: string
+        description: "Name of the distro used in the build. For meta-qcom, the following values are available: nodistro, qcom-distro"
+      distro_suffix:
+        required: false
+        type: string
+        description: "Suffix for the distro name"
+      lava_test_plans_ref:
+        type: string
+        description: "Ref in lava-test-plans repository: commit, tag or branch"
+        required: true
+      testkit_ref:
+        type: string
+        description: "Ref in qcom-linux-testkit repository: CalVer tag or commit SHA"
+        required: true
+      project_name:
+        required: true
+        type: string
+        description: "Name of the project in lava-test-plans"
+      pr_number:
+        required: false
+        type: string
+        description: "Pull request number. Added to the LAVA job metadata for PR builds"
+      pr_url:
+        required: false
+        type: string
+        description: "Pull request URL. Added to the LAVA job metadata for PR builds"
+    outputs:
+      summary_id:
+        description: "ID of the test summary artifact"
+        value: ${{ jobs.publish-test-summary.outputs.summary_id }}
+
+jobs:
+  prepare-boot-jobs:
+    name: "Prepare boot jobs for ${{ inputs.distro_name }}"
+    runs-on: ubuntu-latest
+    outputs:
+      jobmatrix: ${{ steps.lava-test-plans.outputs.jobmatrix }}
+      artifact_id: ${{ steps.lava-test-plans.outputs.artifact_id }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run lava-test-plans
+        id: lava-test-plans
+        uses: qualcomm-linux/meta-qcom/.github/actions/lava-test-plans@master
+        with:
+          machines: ${{ inputs.devices }}
+          distro_name: ${{ inputs.distro_name }}${{ inputs.distro_suffix }}
+          build_id: ${{ inputs.build_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: boottest
+          project: ${{ inputs.project_name }}
+          testplan: "${{ inputs.distro_name }}/boot"
+          ref: ${{ inputs.lava_test_plans_ref }}
+          testkit_ref: ${{ inputs.testkit_ref }}
+          pr_number: ${{ inputs.pr_number }}
+          pr_url: ${{ inputs.pr_url }}
+
+      - name: Print output ID
+        env:
+          JOBMATRIX: "${{ steps.lava-test-plans.outputs.jobmatrix }}"
+          ARTIFACT_ID: "${{ steps.lava-test-plans.outputs.artifact_id }}"
+        run: |
+          echo "${ARTIFACT_ID}"
+          echo "${JOBMATRIX}"
+
+  submit-boot-job:
+    needs: prepare-boot-jobs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    name: Boot ${{ matrix.target.name }}
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-boot-jobs.outputs.jobmatrix) }}
+    steps:
+      - name: 'Download job templates'
+        uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ needs.prepare-boot-jobs.outputs.artifact_id }}
+      - name: "List files"
+        shell: bash
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -R $GITHUB_WORKSPACE
+
+      - name: Submit ${{ matrix.target.name }}
+        # Set timeout to 2h. The timeout starts when the job is submitted
+        # It may spend some time in LAVA queue as there is a limited number
+        # of devices
+        timeout-minutes: 120
+        id: submit
+        uses: foundriesio/lava-action@v13
+        with:
+          lava_token: ${{ secrets.LAVATOKEN }}
+          lava_url: 'lava.infra.foundries.io'
+          job_definition: ${{ matrix.target.path }}
+          wait_for_job: true
+          fail_action_on_failure: true
+          fail_action_on_incomplete: true
+          save_result_as_artifact: true
+          save_job_details: true
+          result_file_name: "${{ matrix.target.result_file }}"
+          test_job_file_name_prefix: "${{ inputs.distro_name }}${{ inputs.distro_suffix }}-"
+      - uses: qualcomm-linux/github-action-matrix-outputs-write@v3
+        if: always()
+        id: out
+        with:
+          matrix-step-name: "${{ github.job }}-${{ inputs.distro_name }}${{ inputs.distro_suffix }}"
+          matrix-key: ${{ matrix.target.name }}-${{ inputs.distro_name }}${{ inputs.distro_suffix }}
+          artifact-name: ${{ github.job }}-${{ inputs.distro_name }}${{ inputs.distro_suffix }}-${{ matrix.target.name }}
+          outputs: |-
+            result: ${{ steps.submit.outcome }}
+
+  boot-job-result:
+    runs-on: ubuntu-latest
+    needs: [submit-boot-job]
+    outputs:
+      boot_result: "${{ steps.print-boot-result.outputs.boot_result }}"
+    steps:
+      - uses: qualcomm-linux/github-action-matrix-outputs-read@2b2498aa0fc6c565e02af0f3a3c5b7e1b6ae07f4
+        id: read
+        with:
+          matrix-step-name: "submit-boot-job-${{ inputs.distro_name }}${{ inputs.distro_suffix }}"
+          download-file-pattern: "submit-boot-job-${{ inputs.distro_name }}${{ inputs.distro_suffix }}*"
+      - id: print-boot-result
+        name: "Print boot result"
+        env:
+          OUTPUTS_RESULT: "${{ steps.read.outputs.result }}"
+        run: |
+          # collapse results of matrix of boot test jobs to a single result
+          yq --version
+
+          BOOT_RESULT="failure"
+          echo "${OUTPUTS_RESULT}" | yq
+          RESULT=$(echo "${OUTPUTS_RESULT}" | yq '.result | [.[]] | all_c(. == "success")')
+          # RESULT will be true only if there are no failures
+          if [ "$RESULT" == "true" ]; then
+            BOOT_RESULT="success"
+          fi
+          echo "boot_result=$BOOT_RESULT"
+          echo "boot_result=$BOOT_RESULT" >> "$GITHUB_OUTPUT"
+
+  prepare-premerge-jobs:
+    name: "Prepare pre-merge jobs for ${{ inputs.distro_name }}"
+    runs-on: ubuntu-latest
+    needs: boot-job-result
+    # run only if boot jobs are successful
+    if: ${{ needs.boot-job-result.outputs.boot_result == 'success' &&
+            inputs.devices_premerge != '' }}
+
+    outputs:
+      jobmatrix: ${{ steps.lava-test-plans.outputs.jobmatrix }}
+      artifact_id: ${{ steps.lava-test-plans.outputs.artifact_id }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine device list
+        id: determine-device-list
+        env:
+          INPUTS_DEVICES_PREMERGE: "${{ inputs.devices_premerge }}"
+        run: |
+          PREMERGE_DEVICE_LIST=""
+          if [ -n "${INPUTS_DEVICES_PREMERGE}" ]; then
+            PREMERGE_DEVICE_LIST="${INPUTS_DEVICES_PREMERGE}"
+          fi
+          echo "PREMERGE_DEVICE_LIST=${PREMERGE_DEVICE_LIST}" >> $GITHUB_OUTPUT
+
+      - name: Run lava-test-plans
+        id: lava-test-plans
+        uses: qualcomm-linux/meta-qcom/.github/actions/lava-test-plans@master
+        with:
+          machines: ${{ steps.determine-device-list.outputs.PREMERGE_DEVICE_LIST }}
+          distro_name: ${{ inputs.distro_name }}${{ inputs.distro_suffix }}
+          build_id: ${{ inputs.build_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: premerge
+          project: ${{ inputs.project_name }}
+          testplan: "${{ inputs.distro_name }}/pre-merge"
+          ref: ${{ inputs.lava_test_plans_ref }}
+          testkit_ref: ${{ inputs.testkit_ref }}
+          pr_number: ${{ inputs.pr_number }}
+          pr_url: ${{ inputs.pr_url }}
+
+      - name: Print output ID
+        env:
+          JOBMATRIX: "${{ steps.lava-test-plans.outputs.jobmatrix }}"
+          ARTIFACT_ID: "${{ steps.lava-test-plans.outputs.artifact_id }}"
+        run: |
+          echo "${ARTIFACT_ID}"
+          echo "${JOBMATRIX}"
+
+  submit-premerge-job:
+    needs: prepare-premerge-jobs
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    name: Pre-merge ${{ matrix.target.name }}
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-premerge-jobs.outputs.jobmatrix) }}
+    steps:
+      - name: 'Download job templates'
+        uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ needs.prepare-premerge-jobs.outputs.artifact_id }}
+
+      - name: Submit ${{ matrix.target.name }}
+        # Set timeout to 2h. The timeout starts when the job is submitted
+        # It may spend some time in LAVA queue as there is a limited number
+        # of devices
+        timeout-minutes: 120
+        uses: foundriesio/lava-action@v13
+        with:
+          lava_token: ${{ secrets.LAVATOKEN }}
+          lava_url: 'lava.infra.foundries.io'
+          job_definition: ${{ matrix.target.path }}
+          wait_for_job: true
+          fail_action_on_failure: true
+          fail_action_on_incomplete: true
+          save_result_as_artifact: true
+          save_job_details: true
+          result_file_name: "${{ matrix.target.result_file }}"
+          test_job_file_name_prefix: "${{ inputs.distro_name }}${{ inputs.distro_suffix }}-"
+
+  publish-test-summary:
+    name: "Publish Summary ${{ inputs.distro_name }}${{ inputs.distro_suffix }}"
+    needs: [boot-job-result, submit-premerge-job]
+    if: |
+      always()
+      && contains(needs.*.result, 'success')
+      && !contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+    outputs:
+      summary_id: ${{ steps.generate-summary.outputs.artifact_id }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate Summary
+        id: generate-summary
+        uses: qualcomm-linux/meta-qcom/.github/actions/test-job-summary@master
+        with:
+          build_id: ${{ github.run_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: "${{ inputs.distro_name }}${{ inputs.distro_suffix }}-test-job*"
+          summary_file_name: "${{ inputs.distro_name }}${{ inputs.distro_suffix }}-test_job_summary"
+          summary_title: "${{ inputs.distro_name }}${{ inputs.distro_suffix }}"
+
+      - name: Download Summary
+        uses: actions/download-artifact@v7
+        with:
+          artifact-ids: ${{ steps.generate-summary.outputs.artifact_id }}
+
+      - name: Publish Test Job Details
+        env:
+          INPUTS_DISTRO_NAME: "${{ inputs.distro_name }}"
+          INPUTS_DISTRO_SUFFIX: "${{ inputs.distro_suffix }}"
+        run: |
+            cat ${INPUTS_DISTRO_NAME}${INPUTS_DISTRO_SUFFIX}-test_job_summary >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -64,6 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run lava-test-plans
@@ -180,6 +181,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Determine device list
@@ -265,6 +267,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Generate Summary

--- a/.github/workflows/test-distro.yml
+++ b/.github/workflows/test-distro.yml
@@ -48,6 +48,10 @@ on:
       summary_id:
         description: "ID of the test summary artifact"
         value: ${{ jobs.publish-test-summary.outputs.summary_id }}
+    secrets:
+      LAVATOKEN:
+        required: true
+        description: "Token used to submit jobs to the LAVA lab"
 
 jobs:
   prepare-boot-jobs:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -18,15 +18,14 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  checks: write
-  pull-requests: write
   contents: read
-  packages: read
-  actions: read
 
 jobs:
   determine-target-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     outputs:
       branch: ${{ steps.branch.outputs.value }}
       pr_number: ${{ steps.branch.outputs.pr_number }}
@@ -60,6 +59,11 @@ jobs:
   test:
     needs: determine-target-branch
     if: github.event.workflow_run.conclusion == 'success' && needs.determine-target-branch.outputs.branch == 'main'
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
@@ -71,6 +75,10 @@ jobs:
     name: "Comment on PR"
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     steps:
 
       - name: Download Result Summary
@@ -120,6 +128,12 @@ jobs:
           comment-tag: test-results
 
   publish-test-results:
+    permissions:
+      contents: read
+      packages: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/publish-results.yml
     secrets: inherit
     needs: [test]

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -32,7 +32,7 @@ jobs:
         id: download-result-summary
         uses: actions/download-artifact@v7
         with:
-          artifact-ids: ${{ needs.test.outputs.summary_id }}
+          artifact-ids: ${{ needs.test.outputs.summary_ids }}
           path: results_summary
 
       - name: Download event file
@@ -53,8 +53,13 @@ jobs:
           echo "## Test run [workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" > pr-comment.txt
           echo "## Test jobs for commit ${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" >> pr-comment.txt
           PR_NUMBER=$(cat "artifacts/Event File/event.json" | jq -r ".number")
-          RESULT_FILE_NAME=$(find ./results_summary/ -type f)
-          cat "${RESULT_FILE_NAME}" >> pr-comment.txt
+          for RESULT_FILE_NAME in $(find ./results_summary/ -type f)
+          do
+              # <summary> lines cover both number of tests
+              # and the table with the list of all jobs
+              # omit the list of all jobs from shortened summary
+              cat "${RESULT_FILE_NAME}" | grep "summary" | grep -v "All jobs summary" >> pr-comment.txt
+          done
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         env:
           GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -3,7 +3,11 @@ name: Test PR build
 run-name: "Tests triggered by PR: ${{ github.event.workflow_run.display_title }}"
 
 on:
-  workflow_run:
+  # workflow_run is the intended privilege separation: the build runs
+  # unprivileged on pull_request (fork token is read-only) and this chain
+  # runs in the base context to submit LAVA jobs and publish results,
+  # consuming the build's artifacts as data, never executing its code.
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Build on PR"]
     types:
       - completed

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -8,19 +8,64 @@ on:
     types:
       - completed
 
+# Cancel an in-flight test run for a PR when a newer commit (re)triggers the
+# build. This stops an orphaned commit's run from continuing to publish the
+# "Test Results" check and PR comment after the PR head has moved on, so the
+# only surviving results belong to the current head. Re-running failed jobs on
+# an existing run keeps the same run id and is therefore not cancelled.
+concurrency:
+  group: test-pr-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions:
   checks: write
   pull-requests: write
   contents: read
   packages: read
+  actions: read
 
 jobs:
+  determine-target-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.branch.outputs.value }}
+      pr_number: ${{ steps.branch.outputs.pr_number }}
+      pr_url: ${{ steps.branch.outputs.pr_url }}
+    steps:
+      # github.event.workflow_run.pull_requests is empty for PRs opened from
+      # forked repositories, so the target branch can't be read from the event
+      # payload. Read it instead from the Event File artifact uploaded by the
+      # build: it is the literal pull_request event that triggered the build and
+      # therefore identifies the target branch reliably, forks included.
+      - name: Download event file
+        uses: actions/download-artifact@v7
+        with:
+          name: Event File
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+      - id: branch
+        run: |
+          BRANCH=$(jq -r '.pull_request.base.ref // "main"' event.json)
+          echo "::notice title=Target branch::Resolved target branch: $BRANCH"
+          echo "value=$BRANCH" >> "$GITHUB_OUTPUT"
+          # PR number and URL are taken from the pull_request event payload and
+          # forwarded to the test workflow so they can be embedded in the LAVA
+          # test job metadata section.
+          PR_NUMBER=$(jq -r '.number // .pull_request.number // ""' event.json)
+          PR_URL=$(jq -r '.pull_request.html_url // ""' event.json)
+          echo "::notice title=Pull request::PR #${PR_NUMBER} (${PR_URL})"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
   test:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs: determine-target-branch
+    if: github.event.workflow_run.conclusion == 'success' && needs.determine-target-branch.outputs.branch == 'main'
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
       build_id: ${{ github.event.workflow_run.id }}
+      pr_number: ${{ needs.determine-target-branch.outputs.pr_number }}
+      pr_url: ${{ needs.determine-target-branch.outputs.pr_url }}
 
   comment-on-pr:
     name: "Comment on PR"
@@ -49,9 +94,11 @@ jobs:
 
       - name: Prepare PR comment
         id: pr_comment_prep
+        env:
+          GH_EVENT_WORKFLOW_RUN_HEAD_SHA: "${{ github.event.workflow_run.head_sha }}"
         run: |
-          echo "## Test run [workflow](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" > pr-comment.txt
-          echo "## Test jobs for commit ${GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA}" >> pr-comment.txt
+          echo "## Test run [workflow](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" > pr-comment.txt
+          echo "## Test jobs for commit ${GH_EVENT_WORKFLOW_RUN_HEAD_SHA}" >> pr-comment.txt
           PR_NUMBER=$(cat "artifacts/Event File/event.json" | jq -r ".number")
           for RESULT_FILE_NAME in $(find ./results_summary/ -type f)
           do
@@ -61,14 +108,16 @@ jobs:
               cat "${RESULT_FILE_NAME}" | grep "summary" | grep -v "All jobs summary" >> pr-comment.txt
           done
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
 
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3
         with:
           file-path: pr-comment.txt
           pr-number: ${{ steps.pr_comment_prep.outputs.pr_number }}
+          # Update a single tagged comment per PR instead of posting a new one on
+          # every run, so the PR shows one current result instead of accumulating
+          # stale comments (one per run / per superseded commit).
+          comment-tag: test-results
 
   publish-test-results:
     uses: ./.github/workflows/publish-results.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ jobs:
   test-qcom-distro:
     needs: [prepare-env]
     name: "Test qcom-distro"
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test-distro.yml
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}
@@ -59,6 +64,11 @@ jobs:
   test-qcom-distro_linux-qcom-next:
     needs: [prepare-env]
     name: "Test qcom-distro_linux-qcom-next"
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
     uses: ./.github/workflows/test-distro.yml
     secrets:
       LAVATOKEN: ${{ secrets.LAVATOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,220 +6,71 @@ on:
       build_id:
         required: true
         type: string
+      pr_number:
+        required: false
+        type: string
+        description: "Pull request number. Added to the LAVA job metadata for PR builds"
+      pr_url:
+        required: false
+        type: string
+        description: "Pull request URL. Added to the LAVA job metadata for PR builds"
     outputs:
-      summary_id:
-        description: "ID of the test summary artifact"
-        value: ${{ jobs.publish-test-summary.outputs.summary_id }}
+      summary_ids:
+        description: "IDs of the test summary artifact"
+        value: ${{ jobs.collect-ids.outputs.summary_ids }}
+env:
+  # git sha, tag or branch in lava-test-plans repository
+  LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
+  # CalVer tag in qcom-linux-testkit repository (format: testkit-YYYY.MM.DD)
+  TESTKIT_REF: "testkit-2026.08.14"
 
 jobs:
-  prepare-boot-jobs:
+  prepare-env:
+    name: Prepare environment
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        machine:
-          - iq-8275-evk
-          - iq-9075-evk
-          - iq-x7181-evk
-          - qcm6490-idp
-          - qcs615-ride
-          - rb3gen2-core-kit
-          - qcs8300-ride-sx
-          - qcs9100-ride-sx
-          - qcom-armv8a
-          - qcom-armv7a
-          - rb1-core-kit
-        distro:
-          - name: qcom-distro
-        kernel:
-          - ""
     steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Run lava-test-plans
-        uses: qualcomm-linux/meta-qcom/.github/actions/lava-test-plans@master
-        with:
-          machine: ${{ matrix.machine }}
-          distro_name: ${{ matrix.distro.name }}
-          kernel: ${{ matrix.kernel }}
-          build_id: ${{ inputs.build_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: boottest
-
-  prepare-boot-job-list:
-    needs: prepare-boot-jobs
-    runs-on: ubuntu-latest
-    outputs:
-      jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: "List jobs"
-        id: listjobs
-        uses: qualcomm-linux/meta-qcom/.github/actions/list-jobs@master
-        with:
-          prefix: "boottest"
-          build_id: ${{ github.run_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-
-  submit-boot-job:
-    needs: prepare-boot-job-list
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    name: Boot ${{ matrix.target.name }}
-    strategy:
-      matrix: ${{ fromJson(needs.prepare-boot-job-list.outputs.jobmatrix) }}
-    steps:
-      - name: 'Download job templates'
-        uses: actions/download-artifact@v7
-        with:
-          name: ${{ matrix.target.artifact }}
-
-      - name: Submit ${{ matrix.target.name }}
-        timeout-minutes: 20
-        id: submit
-        uses: foundriesio/lava-action@v11
-        with:
-          lava_token: ${{ secrets.LAVATOKEN }}
-          lava_url: 'lava.infra.foundries.io'
-          job_definition: ${{ matrix.target.path }}
-          wait_for_job: true
-          fail_action_on_failure: true
-          fail_action_on_incomplete: true
-          save_result_as_artifact: true
-          save_job_details: true
-          result_file_name: "${{ matrix.target.result_file }}"
-      - uses: mwasilew/github-action-matrix-outputs-write@f7202d2224ebed937f287a2e2813e47fddd12bc8 # v2
-        if: always()
-        id: out
-        with:
-          matrix-step-name: ${{ github.job }}
-          matrix-key: ${{ matrix.target.name }}
-          artifact-name: ${{ matrix.target.name }}
-          outputs: |-
-            result: ${{ steps.submit.outcome }}
-
-
-  boot-job-result:
-    runs-on: ubuntu-latest
-    needs: [submit-boot-job]
-    outputs:
-      boot_result: "${{ steps.print-boot-result.outputs.boot_result }}"
-    steps:
-      - uses: cloudposse/github-action-matrix-outputs-read@33cac12fa9282a7230a418d859b93fdbc4f27b5a # v1
-        id: read
-        with:
-          matrix-step-name: "submit-boot-job"
-      - id: print-boot-result
-        name: "Print boot result"
+      - name: "Print ref"
+        shell: bash
         run: |
-          # collapse results of matrix of boot test jobs to a single result
-          echo '${{ steps.read.outputs.result }}' | yq
-          BOOT_RESULT=$(echo '${{ steps.read.outputs.result }}' | yq '.[] | first (. != "success")')
-          if [ -z "$BOOT_RESULT" ]; then
-            BOOT_RESULT="success"
-          fi
-          echo "boot_result=$BOOT_RESULT"
-          echo "boot_result=$BOOT_RESULT" >> "$GITHUB_OUTPUT"
-
-  prepare-premerge-jobs:
-    needs: boot-job-result
-    # run only if boot jobs are successful
-    if: ${{ needs.boot-job-result.outputs.boot_result == 'success' }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # only run pre-merge tests on devices available in the LAB
-        # and "contemporary" - exclude dragonboards
-        machine:
-          - iq-9075-evk
-          - qcs615-ride
-          - rb3gen2-core-kit
-          - qcs8300-ride-sx
-          - qcs9100-ride-sx
-          - rb1-core-kit
-        distro:
-          - name: qcom-distro
-        kernel:
-          - ""
-    steps:
-      - id: print-condition
-        name: "Print condition"
-        env:
-          RESULT: ${{ needs.boot-job-result.outputs.boot_result }}
-        run: |
-          echo "${RESULT}"
-
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Run lava-test-plans
-        uses: qualcomm-linux/meta-qcom/.github/actions/lava-test-plans@master
-        with:
-          machine: ${{ matrix.machine }}
-          distro_name: ${{ matrix.distro.name }}
-          kernel: ${{ matrix.kernel }}
-          build_id: ${{ inputs.build_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          prefix: premerge
-          testplan: pre-merge
-
-  prepare-premerge-job-list:
-    needs: prepare-premerge-jobs
-    runs-on: ubuntu-latest
+          echo "lava-test-plans ref: ${{ env.LAVA_TEST_PLANS_REF }}"
     outputs:
-      jobmatrix: ${{ steps.listjobs.outputs.jobmatrix }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+      lava-test-plans-ref: "${{ env.LAVA_TEST_PLANS_REF }}"
+      testkit-ref: "${{ env.TESTKIT_REF }}"
+  test-qcom-distro:
+    needs: [prepare-env]
+    name: "Test qcom-distro"
+    uses: ./.github/workflows/test-distro.yml
+    secrets: inherit
+    with:
+      build_id: "${{ inputs.build_id }}"
+      devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,qcom-armv8a,qcom-armv7a,rb1-core-kit"
+      devices_premerge: "iq-9075-evk,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      project_name: "meta-qcom-distro"
+      distro_name: "qcom-distro"
+      lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
+      testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
+      pr_number: "${{ inputs.pr_number }}"
+      pr_url: "${{ inputs.pr_url }}"
+  test-qcom-distro_linux-qcom-next:
+    needs: [prepare-env]
+    name: "Test qcom-distro_linux-qcom-next"
+    uses: ./.github/workflows/test-distro.yml
+    secrets: inherit
+    with:
+      build_id: "${{ inputs.build_id }}"
+      devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,qcom-armv8a,rb1-core-kit"
+      devices_premerge: "iq-9075-evk,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,rb1-core-kit"
+      project_name: "meta-qcom-distro"
+      distro_name: "qcom-distro"
+      distro_suffix: "_linux-qcom-next"
+      lava_test_plans_ref: "${{ needs.prepare-env.outputs.lava-test-plans-ref }}"
+      testkit_ref: "${{ needs.prepare-env.outputs.testkit-ref }}"
+      pr_number: "${{ inputs.pr_number }}"
+      pr_url: "${{ inputs.pr_url }}"
 
-      - name: "List jobs"
-        id: listjobs
-        uses: qualcomm-linux/meta-qcom/.github/actions/list-jobs@master
-        with:
-          prefix: "premerge"
-          build_id: ${{ github.run_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-
-  submit-premerge-job:
-    needs: prepare-premerge-job-list
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    name: Pre-merge ${{ matrix.target.name }}
-    strategy:
-      matrix: ${{ fromJson(needs.prepare-premerge-job-list.outputs.jobmatrix) }}
-    steps:
-      - name: 'Download job templates'
-        uses: actions/download-artifact@v7
-        with:
-          name: ${{ matrix.target.artifact}}
-
-      - name: Submit ${{ matrix.target.name }}
-        timeout-minutes: 20
-        uses: foundriesio/lava-action@v11
-        with:
-          lava_token: ${{ secrets.LAVATOKEN }}
-          lava_url: 'lava.infra.foundries.io'
-          job_definition: ${{ matrix.target.path }}
-          wait_for_job: true
-          fail_action_on_failure: true
-          fail_action_on_incomplete: true
-          save_result_as_artifact: true
-          save_job_details: true
-          result_file_name: "${{ matrix.target.result_file }}"
-
-  publish-test-summary:
-    name: "Publish Tests Summary"
-    needs: [submit-premerge-job, submit-boot-job]
+  collect-ids:
+    name: "Collect Summary artifact IDs"
+    needs: [test-qcom-distro, test-qcom-distro_linux-qcom-next]
     if: |
       always()
       && contains(needs.*.result, 'success')
@@ -229,27 +80,12 @@ jobs:
       checks: write
       pull-requests: write
     outputs:
-      summary_id: ${{ steps.generate-summary.outputs.artifact_id }}
-
+      summary_ids: ${{ steps.generate-summary.outputs.artifact_ids }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Generate Summary
+      - name: Summary IDs
         id: generate-summary
-        uses: qualcomm-linux/meta-qcom/.github/actions/test-job-summary@master
-        with:
-          build_id: ${{ github.run_id }}
-          gh_token: ${{ secrets.GITHUB_TOKEN }}
-          summary_file_name: test_job_summary
-
-      - name: Download Summary
-        uses: actions/download-artifact@v7
-        with:
-          artifact-ids: ${{ steps.generate-summary.outputs.artifact_id }}
-
-      - name: Publish Test Job Details
+        env:
+          QCOM_DISTRO_SUMMARY_ID: ${{ needs.test-qcom-distro.outputs.summary_id }}
+          QCOM_DISTRO_NEXT_SUMMARY_ID: ${{ needs.test-qcom-distro_linux-qcom-next.outputs.summary_id }}
         run: |
-            cat test_job_summary >> $GITHUB_STEP_SUMMARY
+          echo "artifact_ids=${QCOM_DISTRO_SUMMARY_ID},${QCOM_DISTRO_NEXT_SUMMARY_ID}" >> $GITHUB_OUTPUT

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,10 @@ on:
       summary_ids:
         description: "IDs of the test summary artifact"
         value: ${{ jobs.collect-ids.outputs.summary_ids }}
+    secrets:
+      LAVATOKEN:
+        required: true
+        description: "Token used to submit jobs to the LAVA lab"
 env:
   # git sha, tag or branch in lava-test-plans repository
   LAVA_TEST_PLANS_REF: "a20c74e6827b87ca39dff33eff4769d860e7942c"
@@ -40,7 +44,8 @@ jobs:
     needs: [prepare-env]
     name: "Test qcom-distro"
     uses: ./.github/workflows/test-distro.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,qcom-armv8a,qcom-armv7a,rb1-core-kit"
@@ -55,7 +60,8 @@ jobs:
     needs: [prepare-env]
     name: "Test qcom-distro_linux-qcom-next"
     uses: ./.github/workflows/test-distro.yml
-    secrets: inherit
+    secrets:
+      LAVATOKEN: ${{ secrets.LAVATOKEN }}
     with:
       build_id: "${{ inputs.build_id }}"
       devices: "iq-8275-evk,iq-9075-evk,iq-x7181-evk,qcm6490-idp,qcs615-ride,rb3gen2-core-kit,qcs8300-ride-sx,qcs9100-ride-sx,qcom-armv8a,rb1-core-kit"


### PR DESCRIPTION
Backport of #444 to `wrynose`, together with the two build-yocto PRs it
builds on:

- #301 workflow/build-yocto: skip summary on forks and fail
  build_successful when compile fails. Besides being needed for the #444
  commits to apply cleanly, this closes a real gap on wrynose: GitHub
  treats skipped jobs as successful for required status checks, so a
  failed compile could previously leave build_successful skipped and
  still satisfy branch protection.
- #444 ci: sync .github workflows with meta-qcom (all 10 commits).

Adaptations for wrynose:

- Dropped the `qcom-distro_linux-qcom-6.18` test job and build matrix
  entries: wrynose has no `ci/linux-qcom-6.18.yml`.
- Dropped the `.github/workflows/backport.yml` hunk from the zizmor
  annotation commit: that workflow only exists on main.
- Flipped the second test variant from `linux-qcom-6.18` to
  `linux-qcom-next`: wrynose defaults to the 6.18 LTS kernel (the
  reverse of main), so the non-default kernel worth covering here is
  qcom-next. A new commit adds the matching `linux-qcom-next` build
  variants to the compile matrix, constrained to `qcom-distro` only —
  6.18 is the official and supported kernel on this branch, so
  reference-distro coverage is enough to validate qcom-next.