### PR TITLE
qcom-multimedia-image/redis: nord license fix + redis xxhash/tre build fix

### DIFF
--- a/recipes-extended/redis/redis_%.bbappend
+++ b/recipes-extended/redis/redis_%.bbappend
@@ -3,3 +3,42 @@ FILESEXTRAPATHS:prepend:qcom-distro := "${THISDIR}/files:"
 SRC_URI:append:qcom-distro = " file://0006-tests-modules-do-not-force-host-gcc.patch"
 
 SYSTEMD_AUTO_ENABLE:${PN}:qcom-distro = "disable"
+
+# xxhash.h's XXH_FORCE_INLINE wraps XXH3_accumulate_{neon,scalar} (and other
+# internal helpers) in __attribute__((always_inline)). At -Og (DEBUG_BUILD=1)
+# GCC's inliner heuristics can't satisfy always_inline for these non-trivial
+# functions and hard-errors instead of just losing the optimization -- this
+# hits the scalar path exactly the same as the NEON path, so forcing one SIMD
+# path over another (e.g. XXH_VECTOR=0) doesn't help. xxhash.h documents
+# XXH_NO_INLINE_HINTS for exactly this case: it drops XXH_FORCE_INLINE down to
+# a plain `static` (no always_inline attribute) and lets GCC decide.
+CFLAGS:append:qcom-distro = " -DXXH_NO_INLINE_HINTS=1"
+
+# redis's do_compile() issues two separate `oe_runmake -C deps ...` calls in
+# one generated shell function: this prepend's "tre xxhash", then upstream's
+# unmodified "hdr_histogram fpconv hiredis lua linenoise". deps/Makefile has
+# two INDEPENDENT ifneq guards (CFLAGS vs cached deps/.make-cflags, LDFLAGS vs
+# deps/.make-ldflags), each gating a `distclean` prerequisite -- and
+# distclean's recipe unconditionally ends with a blanket `rm -f .make-*` that
+# deletes BOTH marker files even when only ONE guard actually mismatched.
+# Our -DXXH_NO_INLINE_HINTS=1 CFLAGS addition above makes the CFLAGS guard
+# mismatch on the FIRST oe_runmake call, so its distclean fires and (via the
+# blanket rm) also deletes .make-ldflags, even though LDFLAGS never changed.
+# Call 1 then rebuilds+re-caches .make-cflags and successfully archives
+# libtre.a/libxxhash.a -- but moments later call 2 finds .make-ldflags
+# missing, treats that as an LDFLAGS mismatch, and fires distclean AGAIN,
+# deleting the libtre.a/libxxhash.a call 1 just built. Call 2's own target
+# list never includes tre/xxhash, so they're never rebuilt, and the link
+# step fails with "cannot find .../deps/{tre,xxhash}/lib*.a".
+#
+# Fix: pre-seed BOTH deps/.make-cflags and deps/.make-ldflags with the exact
+# current CFLAGS/LDFLAGS before the first oe_runmake call, so NEITHER guard
+# mismatches on call 1 -- its distclean never fires, so it never touches the
+# marker files, so call 2 also finds both markers already matching and never
+# fires distclean either. tre/xxhash's artifacts then survive to the link.
+do_compile:prepend:qcom-distro() {
+    mkdir -p ${S}/deps
+    echo "$CFLAGS" > ${S}/deps/.make-cflags
+    echo "$LDFLAGS" > ${S}/deps/.make-ldflags
+    oe_runmake -C deps tre xxhash
+}

--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -21,6 +21,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-glymur:LICENSE.qcom-2 \
     firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
     firmware-qcom-boot-kaanapali:LICENSE.qcom-2 \
+    firmware-qcom-boot-nord:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \

--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -21,7 +21,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-glymur:LICENSE.qcom-2 \
     firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
     firmware-qcom-boot-kaanapali:LICENSE.qcom-2 \
-    firmware-qcom-boot-nord:LICENSE.qcom-2 \
+    firmware-qcom-boot-nord:LicenseRef-LICENSE.qcom-2 \
     firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \


### PR DESCRIPTION
Re-opens the work from #435 (closed) for the `iq10-rrd` machine bring-up, plus a new redis build fix found during M0 image build/heal.

**1. qcom-multimedia-image: nord boot-firmware license exception**

Allow `firmware-qcom-boot-nord`'s `LICENSE.qcom-2` (LicenseRef SPDX id) so the nord boot-firmware package is not rejected by license checks.

**2. redis: fix xxhash/tre build failures under -Og debug builds**

`redis`'s `do_compile:prepend:qcom-distro()` omitted `xxhash`/`tre` from the deps it pre-builds, and `xxhash.h`'s `XXH_FORCE_INLINE` (`always_inline`) on `XXH3_accumulate_{neon,scalar}` hard-errors under GCC `-Og`. Additionally, `deps/Makefile` guards CFLAGS/LDFLAGS changes against cached marker files with a shared `distclean` target, so seeding only one marker caused a cross-call cascade that deleted `libtre.a`/`libxxhash.a` before the link step.

- Add `tre`/`xxhash` to the `do_compile:prepend` deps target list.
- Set `-DXXH_NO_INLINE_HINTS=1` to avoid the `always_inline` hard error.
- Pre-seed both `deps/.make-cflags` and `deps/.make-ldflags` so neither guard mismatches and `distclean` never fires mid-build.

Note: a related xxhash/redis fix may already exist upstream in `meta-qcom` PR #2949 (per @ricardosalveti's comment on #432) — worth cross-checking for overlap/upstreaming.

Build verified: `kas build meta-qcom/ci/iq10-rrd.yml:meta-qcom/ci/qcom-distro-catchall.yml:meta-qcom/ci/debug.yml --target qcom-multimedia-image` completes with `EXIT=0`, no `^ERROR:` lines.