### PR TITLE
recipes-multimedia: enable ofono compat mode for native HFP Telephony

### DIFF
--- a/recipes-multimedia/audio/files/bluetooth.conf
+++ b/recipes-multimedia/audio/files/bluetooth.conf
@@ -1,6 +1,11 @@
 ## Move the BlueZ5 native backend's Telephony D-Bus service to the system
 ## bus, since no session bus is available when wireplumber.service runs
 ## in system-wide mode.
+##
+## Also register the service as org.ofono on the system bus, enabling
+## ofono-compatible applications and test scripts to work with the
+## native HFP backend without modification.
 monitor.bluez.properties = {
   bluez5.telephony.use-system-bus = true
+  bluez5.telephony.provide-ofono = true
 }

--- a/recipes-multimedia/pipewire/pipewire/pipewire-telephony-dbus.conf
+++ b/recipes-multimedia/pipewire/pipewire/pipewire-telephony-dbus.conf
@@ -1,7 +1,10 @@
 <!-- This configuration file specifies the required security policies
      for PipeWire native bluez5 backend Telephony service to work on
      the system bus (needed when wireplumber runs as main-systemwide,
-     i.e. no session bus is available). -->
+     i.e. no session bus is available).
+     When bluez5.telephony.provide-ofono is enabled, the service is also
+     registered as org.ofono to allow ofono-compatible applications to
+     work with the native backend. -->
 
 <!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
@@ -10,20 +13,24 @@
   <!-- wireplumber runs as the pipewire user and registers the service -->
   <policy user="pipewire">
     <allow own="org.pipewire.Telephony"/>
+    <allow own="org.ofono"/>
   </policy>
 
   <policy user="root">
     <allow send_destination="org.pipewire.Telephony"/>
+    <allow send_destination="org.ofono"/>
   </policy>
 
   <policy at_console="true">
     <allow send_destination="org.pipewire.Telephony"/>
+    <allow send_destination="org.ofono"/>
   </policy>
 
   <!-- Deny call control to everyone else, matching the oFono policy
        this D-Bus API is modelled on -->
   <policy context="default">
     <deny send_destination="org.pipewire.Telephony"/>
+    <deny send_destination="org.ofono"/>
   </policy>
 
 </busconfig>


### PR DESCRIPTION
Enable bluez5.telephony.provide-ofono in bluetooth.conf so the native backend registers as org.ofono on the system bus, allowing ofono-based applications and test scripts to work directly with the native HFP backend without modification.

Extend the D-Bus policy file to also grant the pipewire user permission to own org.ofono, and allow root/at_console users to call it, with the same deny-by-default policy as org.pipewire.Telephony.

Note: a PipeWire fix for ofono compat interface compatibility issues (GetModems/GetCalls return format, Dial signature) is being submitted upstream separately. Without that fix, some ofono test scripts may not work correctly.