### PR TITLE
systemd: stop boot.mount gating local-fs.target on SOTA

### DIFF
--- a/recipes-core/systemd/systemd/boot.mount-10-no-local-fs-gate.conf
+++ b/recipes-core/systemd/systemd/boot.mount-10-no-local-fs-gate.conf
@@ -1,0 +1,21 @@
+# Boot-time optimization for SOTA/OSTree systems.
+#
+# systemd-gpt-auto-generator creates boot.automount and its backing boot.mount
+# for the EFI System Partition. OSTree's boot-complete service is pulled into
+# the boot transaction and RequiresMountsFor=/boot, which also pulls in the
+# backing mount. A normal local mount receives Before=local-fs.target through
+# its default dependencies, so a delayed ESP device unit can unnecessarily
+# hold local-fs.target and sysinit.target on the critical path.
+#
+# Keep the automount as the local-fs synchronization point and allow the real
+# mount to complete independently. Services that need /boot still wait for it
+# through RequiresMountsFor= or through an autofs access.
+#
+# DefaultDependencies=no also removes the local-fs-pre and shutdown ordering;
+# preserve those relationships explicitly and omit only the
+# Before=local-fs.target dependency.
+[Unit]
+DefaultDependencies=no
+After=local-fs-pre.target
+Conflicts=umount.target
+Before=umount.target

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -2,6 +2,10 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append:qcom-distro = " file://dmaheap-sysusers.conf"
 
+SRC_URI:append:sota = " \
+        file://boot.mount-10-no-local-fs-gate.conf \
+"
+
 do_install:append:qcom-distro() {
     install -d ${D}${libdir}/sysusers.d
     install -m 0644 ${UNPACKDIR}/dmaheap-sysusers.conf \
@@ -9,3 +13,11 @@ do_install:append:qcom-distro() {
 }
 
 FILES:${PN}:append:qcom-distro = " ${libdir}/sysusers.d/dmaheap.conf"
+
+do_install:append:sota() {
+    install -d ${D}${systemd_system_unitdir}/boot.mount.d
+    install -m 0644 ${UNPACKDIR}/boot.mount-10-no-local-fs-gate.conf \
+        ${D}${systemd_system_unitdir}/boot.mount.d/10-no-local-fs-gate.conf
+}
+
+FILES:${PN}:append:sota = " ${systemd_system_unitdir}/boot.mount.d/10-no-local-fs-gate.conf"


### PR DESCRIPTION
This change is ported from:
https://github.com/uptane/meta-updater/pull/222                                                                                                                                                                      
                                                                                                                                                                                                                        
On SOTA/OSTree systems, systemd-gpt-auto-generator creates boot.automount and boot.mount for the EFI System Partition. Due to RequiresMountsFor=/boot, boot.mount can enter the boot transaction. Its default Before=local-fs.target ordering then allows a delayed ESP device to hold local-fs.target.
                                                                                                                                                                                                                        Install a SOTA-only boot.mount drop-in that removes this ordering while preserving the required startup and shutdown dependencies. The change does not affect switch_root or speed up ESP discovery. Consumers that actually require /boot still wait for the backing mount.                                                                                                                                                              
                                                                                                                                                                                                                        
On RB3 Gen 2, local-fs.target improved from 2573 ms to 1416 ms, and
  sysinit.target improved from 2951 ms to 2418 ms.