### PR TITLE
qcom-multimedia-proprietary-image: add RTSS mailbox DLKM/UMD packages

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -27,4 +27,10 @@ CORE_IMAGE_BASE_INSTALL:append = " \
     ${@bb.utils.contains('BBFILE_COLLECTIONS', 'meta-audioreach', ' packagegroup-audioreach', '', d)} \
 "
 
+RTSS_MAILBOX_PACKAGES = "qcom-rtss-mailbox-dlkm qcom-rtss-mailbox-umd qcom-rtss-mailbox-umd-utils"
+CORE_IMAGE_BASE_INSTALL:append:qcs9100-ride-sx = " ${RTSS_MAILBOX_PACKAGES}"
+CORE_IMAGE_BASE_INSTALL:append:qcs8300-ride-sx = " ${RTSS_MAILBOX_PACKAGES}"
+CORE_IMAGE_BASE_INSTALL:append:iq-9075-evk = " ${RTSS_MAILBOX_PACKAGES}"
+CORE_IMAGE_BASE_INSTALL:append:iq-8275-evk = " ${RTSS_MAILBOX_PACKAGES}"
+
 TOOLCHAIN_HOST_TASK:append = " nativesdk-protobuf-camx-compiler"


### PR DESCRIPTION
## Target milestone: QLI-2.1

## Background

The multimedia proprietary image is the shipping image for RTSS-capable targets, and it currently has no path to the RTSS subsystem. CAN communication, RTSS-to-HLOS user space communication, OTA updates, and on-device programming/flashing all depend on the RTSS mailbox IPC path between the application processor and RTSS. Without these packages installed, the image has no way to talk to RTSS at all - the recipes exist (Related PRs below) but are not pulled into any image. This adds that dependency so the image can support those use cases.

## Tracking issue:

https://github.com/qualcomm-linux/meta-qcom/issues/3085

## This PR dependency
- meta-qcom (recipes for qcom-rtss-mailbox-dlkm / qcom-rtss-mailbox-umd):
  - https://github.com/qualcomm-linux/meta-qcom/pull/3084

## Related PRs 

- Device-tree wiring for the mailbox node (`qcom,rtss-mailbox`):
  - https://github.com/qualcomm-linux/kernel-topics/pull/1768
- Image wiring (adds these recipes to qcom-multimedia-proprietary-image in meta-qcom-distro):
  - https://github.com/qualcomm-linux/meta-qcom-distro/pull/457

RTSS interface enablement is handled using a staging DTBO overlay to carry the rtss mailbox node, both bootup and DTBO patching with it applied have been verified on target.

## Testing

- Default bootup verified on lemans and monaco targets with no regression. 
- After RTSS mailbox/staging DT overlay is applied, mailbox communication with RTSS and the CLI utilities were verified on both targets.



