### PR TITLE
ci/qcom-distro: Add LTS mixins layer for connectivity

### DIFF
--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -49,6 +49,10 @@ repos:
     url: https://git.yoctoproject.org/meta-dpdk
     branch: master
 
+  meta-lts-mixins-connectivity:
+    url: https://github.com/qualcomm-linux/meta-lts-mixins
+    branch: wrynose/connectivity
+
 local_conf_header:
   virtualization:
     SKIP_META_VIRT_SANITY_CHECK = "1"


### PR DESCRIPTION
Wrynose intentionally keeps an LTS baseline, while some users need newer versions for selected connectivity components. This branch provides mixin recipes to upgrade hostapd and wpa-supplicant with the latest versions, overriding the oe-core/meta-openembedded versions when explicitly selected. The upgrade enables newer features (including EHT/IEEE 802.11be/Wi-Fi 7) and includes interoperability and security robustness fixes.