### PR TITLE
Allow Nord boot firmware in qcom-multimedia-image

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -21,6 +21,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-glymur:LICENSE.qcom-2 \
     firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
     firmware-qcom-boot-kaanapali:LICENSE.qcom-2 \
+    firmware-qcom-boot-nord:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \


### PR DESCRIPTION
Nord boot firmware is distributed under LICENSE.qcom-2 and is therefore excluded by the image's incompatible license filtering.

Add `firmware-qcom-boot-nord` package providing Nord boot firmware to INCOMPATIBLE_LICENSE_EXCEPTIONS so that the firmware can be included in qcom-multimedia-image while preserving existing license controls.