### PR TITLE
qcom-multimedia-image: match nord boot-firmware LicenseRef SPDX id

### DIFF
--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -21,6 +21,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-glymur:LICENSE.qcom-2 \
     firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
     firmware-qcom-boot-kaanapali:LICENSE.qcom-2 \
+    firmware-qcom-boot-nord:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \

--- a/recipes-products/images/qcom-multimedia-image.bbappend
+++ b/recipes-products/images/qcom-multimedia-image.bbappend
@@ -21,7 +21,7 @@ INCOMPATIBLE_LICENSE_EXCEPTIONS = "\
     firmware-qcom-boot-glymur:LICENSE.qcom-2 \
     firmware-qcom-boot-iq-x7181:LICENSE.qcom-2 \
     firmware-qcom-boot-kaanapali:LICENSE.qcom-2 \
-    firmware-qcom-boot-nord:LICENSE.qcom-2 \
+    firmware-qcom-boot-nord:LicenseRef-LICENSE.qcom-2 \
     firmware-qcom-boot-qcs615:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs6490:LICENSE.qcom-2 \
     firmware-qcom-boot-qcs8300:LICENSE.qcom-2 \


### PR DESCRIPTION
iq10-rrd (NORD SoC) boot firmware ships under LICENSE.qcom-2.

- Add firmware-qcom-boot-nord to INCOMPATIBLE_LICENSE_EXCEPTIONS.
- Correct the exception entry to the LicenseRef-LICENSE.qcom-2 SPDX id
  actually declared by the recipe (bare LICENSE.qcom-2 never matched,
  causing do_populate_lic_deploy to fail under INCOMPATIBLE_LICENSE).

Supersedes #435 and #452 (both closed; #452 additionally mixed in an
unrelated redis fix that has been dropped here).