### PR TITLE
qcom-multimedia-proprietary-image: add qcom-rtss-can

### DIFF
--- a/recipes-products/images/qcom-multimedia-proprietary-image.bb
+++ b/recipes-products/images/qcom-multimedia-proprietary-image.bb
@@ -20,6 +20,7 @@ CORE_IMAGE_BASE_INSTALL += " \
     libdiag-bin \
     onnxruntime-qnn \
     qcom-adreno \
+    qcom-rtss-can \
     qcom-sensors-binaries \
     qwes \
 "


### PR DESCRIPTION
### Target milestone: qli-2.1 pull-request freeze

### Background

Add support for RTSS CAN user-space deamon

### Tracking Issue
https://github.com/qualcomm-linux/meta-qcom/issues/3123

### PR dependency
https://github.com/qualcomm-linux/meta-qcom-distro/pull/457

### Testing
Default bootup verified on lemans and monaco targets with no regression.
